### PR TITLE
Error check first before using scenario

### DIFF
--- a/mandos-go/controller/scenarioOne.go
+++ b/mandos-go/controller/scenarioOne.go
@@ -4,13 +4,13 @@ package mandoscontroller
 func (r *ScenarioRunner) RunSingleJSONScenario(contextPath string) error {
 	scenario, parseErr := ParseMandosScenario(r.Parser, contextPath)
 
+	if parseErr != nil {
+		return parseErr
+	}
+
 	if r.RunsNewTest {
 		scenario.IsNewTest = true
 		r.RunsNewTest = false
-	}
-
-	if parseErr != nil {
-		return parseErr
 	}
 
 	return r.Executor.ExecuteScenario(scenario, r.Parser.ExprInterpreter.FileResolver)


### PR DESCRIPTION
This fixes a crash that occurs when specifying an invalid gas schedule.
With this fix, the proper error message is returned and the test fails without crashing `mandos-test`.