### PR TITLE
Forward-port the runtime instance tracker from VM v1.4

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1,6 +1,8 @@
+// Package executor contains the interfaces and definitions for the VM Executor
 package executor
 
 import (
+	"github.com/multiversx/mx-chain-core-go/core/check"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
@@ -17,6 +19,8 @@ type CompilationOptions struct {
 
 // Executor defines the functionality needed to create any executor instance.
 type Executor interface {
+	check.NilInterfaceChecker
+
 	// SetOpcodeCosts sets gas costs globally inside an executor.
 	SetOpcodeCosts(opcodeCosts *WASMOpcodeCost)
 

--- a/executor/executorInstance.go
+++ b/executor/executorInstance.go
@@ -8,7 +8,7 @@ type Instance interface {
 	SetBreakpointValue(value uint64)
 	GetBreakpointValue() uint64
 	Cache() ([]byte, error)
-	Clean()
+	Clean() bool
 	CallFunction(functionName string) error
 	HasFunction(functionName string) bool
 	GetFunctionNames() []string

--- a/executor/executorInstance.go
+++ b/executor/executorInstance.go
@@ -24,5 +24,6 @@ type Instance interface {
 	Reset() bool
 	SetVMHooksPtr(vmHooksPtr uintptr)
 	GetVMHooksPtr() uintptr
-	Id() string
+	ID() string
+	AlreadyCleaned() bool
 }

--- a/executor/wrapper/wrapperExecutor.go
+++ b/executor/wrapper/wrapperExecutor.go
@@ -75,3 +75,8 @@ func (wexec *WrapperExecutor) addContractInstanceToInstanceMap(code []byte, inst
 func (wexec *WrapperExecutor) GetContractInstances(code []byte) []executor.Instance {
 	return wexec.WrappedInstances[string(code)]
 }
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (wexec *WrapperExecutor) IsInterfaceNil() bool {
+	return wexec == nil
+}

--- a/executor/wrapper/wrapperExecutorFactory.go
+++ b/executor/wrapper/wrapperExecutorFactory.go
@@ -50,3 +50,8 @@ func (factory *WrapperExecutorFactory) CreateExecutor(args executor.ExecutorFact
 	}
 	return factory.LastCreatedExecutor, nil
 }
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (factory *WrapperExecutorFactory) IsInterfaceNil() bool {
+	return factory == nil
+}

--- a/executor/wrapper/wrapperInstance.go
+++ b/executor/wrapper/wrapperInstance.go
@@ -7,6 +7,8 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/executor"
 )
 
+var _ executor.Instance = (*WrapperInstance)(nil)
+
 // WrapperInstance is a wrapper around an executor instance, which adds the possibility of logging operations.
 type WrapperInstance struct {
 	logger          ExecutorLogger
@@ -49,8 +51,17 @@ func (inst *WrapperInstance) Cache() ([]byte, error) {
 }
 
 // Clean wraps the call to the underlying instance.
-func (inst *WrapperInstance) Clean() {
-	inst.wrappedInstance.Clean()
+func (inst *WrapperInstance) Clean() bool {
+	result := inst.wrappedInstance.Clean()
+	inst.logger.LogExecutorEvent(fmt.Sprintf("Clean: %t", result))
+	return result
+}
+
+// AlreadyCleaned wraps the call to the underlying instance.
+func (inst *WrapperInstance) AlreadyCleaned() bool {
+	result := inst.wrappedInstance.AlreadyCleaned()
+	inst.logger.LogExecutorEvent(fmt.Sprintf("AlreadyCleaned: %t", result))
+	return result
 }
 
 // CallFunction wraps the call to the underlying instance.
@@ -140,7 +151,7 @@ func (inst *WrapperInstance) GetVMHooksPtr() uintptr {
 	return inst.wrappedInstance.GetVMHooksPtr()
 }
 
-// Id wraps the call to the underlying instance.
-func (inst *WrapperInstance) Id() string {
-	return inst.wrappedInstance.Id()
+// ID wraps the call to the underlying instance.
+func (inst *WrapperInstance) ID() string {
+	return inst.wrappedInstance.ID()
 }

--- a/integrationTests/features/pureFunctionUtil.go
+++ b/integrationTests/features/pureFunctionUtil.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/multiversx/mx-chain-core-go/hashing/blake2b"
 	vmi "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
@@ -18,6 +19,8 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
 	"github.com/stretchr/testify/require"
 )
+
+var defaultHasher = blake2b.NewBlake2b()
 
 type pureFunctionIO struct {
 	functionName    string
@@ -58,6 +61,7 @@ func newPureFunctionExecutor() (*pureFunctionExecutor, error) {
 			EpochNotifier:            &mock.EpochNotifierStub{},
 			EnableEpochsHandler:      worldhook.EnableEpochsHandlerStubNoFlags(),
 			WasmerSIGSEGVPassthrough: false,
+			Hasher:                   defaultHasher,
 		})
 	if err != nil {
 		return nil, err

--- a/integrationTests/json/scenariosAdderLog_test.go
+++ b/integrationTests/json/scenariosAdderLog_test.go
@@ -66,6 +66,7 @@ VM hook begin: MBufferFromBigIntUnsigned(-105, -104) points used: 63425
 VM hook end:   MBufferFromBigIntUnsigned(-105, -104) points used: 67425
 VM hook begin: MBufferStorageStore(-102, -105) points used: 67437
 VM hook end:   MBufferStorageStore(-102, -105) points used: 142437
+Clean: true
 `
 
 func TestRustAdderLog(t *testing.T) {

--- a/mock/context/executorMock.go
+++ b/mock/context/executorMock.go
@@ -117,3 +117,8 @@ func (executorMock *ExecutorMock) NewInstanceFromCompiledCodeWithOptions(
 	}
 	return wasmer.NewInstanceFromCompiledCodeWithOptions(compiledCode, options)
 }
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (executorMock *ExecutorMock) IsInterfaceNil() bool {
+	return executorMock == nil
+}

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -10,6 +10,8 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/wasmer"
 )
 
+var _ executor.Instance = (*InstanceMock)(nil)
+
 // InstanceMock is a mock for Wasmer instances; it allows creating mock smart
 // contracts within tests, without needing actual WASM smart contracts.
 type InstanceMock struct {
@@ -23,6 +25,7 @@ type InstanceMock struct {
 	Host            vmhost.VMHost
 	T               testing.TB
 	Address         []byte
+	AlreadyClean    bool
 }
 
 // NewInstanceMock creates a new InstanceMock
@@ -84,7 +87,14 @@ func (instance *InstanceMock) Cache() ([]byte, error) {
 }
 
 // Clean mocked method
-func (instance *InstanceMock) Clean() {
+func (instance *InstanceMock) Clean() bool {
+	instance.AlreadyClean = true
+	return true
+}
+
+// AlreadyCleaned mocked method
+func (instance *InstanceMock) AlreadyCleaned() bool {
+	return instance.AlreadyClean
 }
 
 // Reset mocked method
@@ -164,8 +174,8 @@ func GetMockInstance(host vmhost.VMHost) *InstanceMock {
 	return instance
 }
 
-// Id returns an identifier for the instance, unique at runtime
-func (instance *InstanceMock) Id() string {
+// ID returns an identifier for the instance, unique at runtime
+func (instance *InstanceMock) ID() string {
 	return fmt.Sprintf("%p", instance)
 }
 

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -53,6 +53,11 @@ func (r *RuntimeContextMock) GetVMExecutor() executor.Executor {
 func (context *RuntimeContextMock) ReplaceVMExecutor(vmExecutor executor.Executor) {
 }
 
+// GetInstanceTracker mocked method
+func (context *RuntimeContextMock) GetInstanceTracker() vmhost.InstanceTracker {
+	return nil
+}
+
 // StartWasmerInstance mocked method
 func (r *RuntimeContextMock) StartWasmerInstance(_ []byte, _ uint64, _ bool) error {
 	if r.Err != nil {

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -241,6 +241,11 @@ func (r *RuntimeContextMock) GetInstance() executor.Instance {
 	return nil
 }
 
+// GetWarmInstance mocked method
+func (r *RuntimeContextMock) GetWarmInstance(codeHash []byte) (executor.Instance, bool) {
+	return nil, false
+}
+
 // ClearWarmInstanceCache mocked method
 func (r *RuntimeContextMock) ClearWarmInstanceCache() {
 }
@@ -312,6 +317,15 @@ func (r *RuntimeContextMock) AddError(_ error, _ ...string) {
 
 // GetAllErrors mocked method
 func (r *RuntimeContextMock) GetAllErrors() error {
+	return nil
+}
+
+// EndExecution -
+func (r *RuntimeContextMock) EndExecution() {
+}
+
+// ValidateInstances -
+func (r *RuntimeContextMock) ValidateInstances() error {
 	return nil
 }
 

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -117,6 +117,8 @@ type RuntimeContextWrapper struct {
 	ClearStateStackFunc func()
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
 	CleanInstanceFunc func()
+	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
+	GetInstanceTrackerFunc func() vmhost.InstanceTracker
 }
 
 // NewRuntimeContextWrapper builds a new runtimeContextWrapper that by default will delagate all calls to the provided RuntimeContext
@@ -310,6 +312,10 @@ func NewRuntimeContextWrapper(inputRuntimeContext *vmhost.RuntimeContext) *Runti
 
 	runtimeWrapper.CleanInstanceFunc = func() {
 		runtimeWrapper.runtimeContext.CleanInstance()
+	}
+
+	runtimeWrapper.GetInstanceTrackerFunc = func() vmhost.InstanceTracker {
+		return runtimeWrapper.runtimeContext.GetInstanceTracker()
 	}
 
 	return runtimeWrapper
@@ -586,4 +592,9 @@ func (contextWrapper *RuntimeContextWrapper) EndExecution() {
 // ValidateInstances -
 func (contextWrapper *RuntimeContextWrapper) ValidateInstances() error {
 	return nil
+}
+
+// GetInstanceTracker -
+func (contextWrapper *RuntimeContextWrapper) GetInstanceTracker() vmhost.InstanceTracker {
+	return contextWrapper.GetInstanceTrackerFunc()
 }

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -117,8 +117,6 @@ type RuntimeContextWrapper struct {
 	ClearStateStackFunc func()
 	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
 	CleanInstanceFunc func()
-	// function that will be called by the corresponding RuntimeContext function implementation (by default this will call the same wrapped context function)
-	NumRunningInstancesFunc func() (int, int)
 }
 
 // NewRuntimeContextWrapper builds a new runtimeContextWrapper that by default will delagate all calls to the provided RuntimeContext
@@ -312,10 +310,6 @@ func NewRuntimeContextWrapper(inputRuntimeContext *vmhost.RuntimeContext) *Runti
 
 	runtimeWrapper.CleanInstanceFunc = func() {
 		runtimeWrapper.runtimeContext.CleanInstance()
-	}
-
-	runtimeWrapper.NumRunningInstancesFunc = func() (int, int) {
-		return runtimeWrapper.runtimeContext.NumRunningInstances()
 	}
 
 	return runtimeWrapper
@@ -585,7 +579,11 @@ func (contextWrapper *RuntimeContextWrapper) CleanInstance() {
 	contextWrapper.CleanInstanceFunc()
 }
 
-// NumRunningInstances calls corresponding xxxFunc function, that by default in turn calls the original method of the wrapped RuntimeContext
-func (contextWrapper *RuntimeContextWrapper) NumRunningInstances() (int, int) {
-	return contextWrapper.NumRunningInstancesFunc()
+// EndExecution -
+func (contextWrapper *RuntimeContextWrapper) EndExecution() {
+}
+
+// ValidateInstances -
+func (contextWrapper *RuntimeContextWrapper) ValidateInstances() error {
+	return nil
 }

--- a/mock/world/worldAccount.go
+++ b/mock/world/worldAccount.go
@@ -5,9 +5,7 @@ import (
 	"errors"
 	"math/big"
 
-	logger "github.com/multiversx/mx-chain-logger-go"
-	"github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-go/crypto/hashing"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 )
 
 // ErrOperationNotPermitted indicates an operation rejected due to insufficient
@@ -54,11 +52,7 @@ func (a *Account) StorageValue(key string) []byte {
 // The code metadata must be given explicitly.
 func (a *Account) SetCodeAndMetadata(code []byte, codeMetadata *vmcommon.CodeMetadata) {
 	a.Code = code
-	hasher := hashing.NewHasher()
-	hash, err := hasher.Sha256(code)
-	if err != nil {
-		logger.GetOrCreate("worldAccount").Trace("Account.SetCodeAndMetadata", "error", err)
-	}
+	hash := DefaultHasher.Compute(string(a.Code))
 
 	a.CodeHash = hash
 	a.IsSmartContract = true
@@ -128,8 +122,7 @@ func (a *Account) IsInterfaceNil() bool {
 // SetCode -
 func (a *Account) SetCode(code []byte) {
 	a.Code = code
-	hasher := hashing.NewHasher()
-	a.CodeHash, _ = hasher.Sha256(code)
+	a.CodeHash = DefaultHasher.Compute(string(code))
 	a.IsSmartContract = true
 }
 

--- a/mock/world/worldAccountMap.go
+++ b/mock/world/worldAccountMap.go
@@ -7,7 +7,6 @@ import (
 	"math/big"
 
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-go/crypto/hashing"
 )
 
 // AccountMap is a map from address to Account, also implementing the
@@ -71,7 +70,7 @@ func (am AccountMap) CreateSmartContractAccountWithCodeHash(owner []byte, addres
 // PutAccount inserts account based on address.
 func (am AccountMap) PutAccount(account *Account) {
 	if account.Code != nil && account.CodeHash == nil {
-		hash, _ := hashing.NewHasher().Sha256(account.Code)
+		hash := DefaultHasher.Compute(string(account.Code))
 		account.CodeHash = hash
 	}
 	am[string(account.Address)] = account

--- a/scenarioexec/exec.go
+++ b/scenarioexec/exec.go
@@ -3,6 +3,7 @@ package scenarioexec
 import (
 	"fmt"
 
+	"github.com/multiversx/mx-chain-core-go/core"
 	logger "github.com/multiversx/mx-chain-logger-go"
 	vmi "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
@@ -81,7 +82,7 @@ func (ae *VMTestExecutor) InitVM(scenGasSchedule mj.GasSchedule) error {
 			BlockGasLimit:            blockGasLimit,
 			GasSchedule:              gasSchedule,
 			BuiltInFuncContainer:     ae.World.BuiltinFuncs.Container,
-			ProtectedKeyPrefix:       []byte(ProtectedKeyPrefix),
+			ProtectedKeyPrefix:       []byte(core.ProtectedKeyPrefix),
 			ESDTTransferParser:       esdtTransferParser,
 			EpochNotifier:            &mock.EpochNotifierStub{},
 			EnableEpochsHandler:      worldhook.EnableEpochsHandlerStubAllFlags(),

--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -7,6 +7,7 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/config"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
 	"github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/stretchr/testify/require"
 )
 
 // InstanceTestSmartContract represents the config data for the smart contract instance to be tested
@@ -122,6 +123,10 @@ func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
 		if reset {
 			callerTest.host.Reset()
 		}
+
+		// Extra verification for instance leaks
+		err := callerTest.host.Runtime().ValidateInstances()
+		require.Nil(callerTest.tb, err)
 	}()
 
 	vmOutput, err := callerTest.host.RunSmartContractCall(callerTest.input)

--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -96,6 +96,11 @@ func (callerTest *InstancesTestTemplate) WithWasmerSIGSEGVPassthrough(wasmerSIGS
 	return callerTest
 }
 
+// GetVMHost returns the inner VMHost
+func (callerTest *InstancesTestTemplate) GetVMHost() vmhost.VMHost {
+	return callerTest.host
+}
+
 // AndAssertResults starts the test and asserts the results
 func (callerTest *InstancesTestTemplate) AndAssertResults(assertResults func(vmhost.VMHost, *contextmock.BlockchainHookStub, *VMOutputVerifier)) {
 	callerTest.assertResults = assertResults

--- a/testcommon/instanceSmartContractCreatorTest.go
+++ b/testcommon/instanceSmartContractCreatorTest.go
@@ -8,6 +8,7 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/executor"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
 	"github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/stretchr/testify/require"
 )
 
 // TestCreateTemplateConfig holds the data to build a contract creation test
@@ -85,6 +86,10 @@ func (callerTest *TestCreateTemplateConfig) runTest(reset bool) {
 		if reset {
 			callerTest.host.Reset()
 		}
+
+		// Extra verification for instance leaks
+		err := callerTest.host.Runtime().ValidateInstances()
+		require.Nil(callerTest.t, err)
 	}()
 
 	vmOutput, err := callerTest.host.RunSmartContractCreate(callerTest.input)

--- a/testcommon/testInitializerInputs.go
+++ b/testcommon/testInitializerInputs.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
+	"github.com/multiversx/mx-chain-core-go/hashing/blake2b"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
@@ -25,6 +26,8 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
 	"github.com/stretchr/testify/require"
 )
+
+var defaultHasher = blake2b.NewBlake2b()
 
 // DefaultVMType is an exposed value to use in tests
 var DefaultVMType = []byte{0xF, 0xF}
@@ -139,6 +142,7 @@ func NewTestHostBuilder(tb testing.TB) *TestHostBuilder {
 			EpochNotifier:            &mock.EpochNotifierStub{},
 			EnableEpochsHandler:      worldmock.EnableEpochsHandlerStubAllFlags(),
 			WasmerSIGSEGVPassthrough: false,
+			Hasher:                   defaultHasher,
 		},
 	}
 }

--- a/testcommon/testInitializerInputs.go
+++ b/testcommon/testInitializerInputs.go
@@ -17,7 +17,6 @@ import (
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
 	"github.com/multiversx/mx-chain-vm-go/config"
-	"github.com/multiversx/mx-chain-vm-go/crypto/hashing"
 	"github.com/multiversx/mx-chain-vm-go/executor"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
 	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
@@ -315,7 +314,7 @@ func BlockchainHookStubForContracts(
 	codeMap := make(map[string]*[]byte)
 
 	for _, contract := range contracts {
-		codeHash, _ := hashing.NewHasher().Sha256(contract.code)
+		codeHash := defaultHasher.Compute(string(contract.code))
 		contractsMap[string(contract.address)] = &contextmock.StubAccount{
 			Address:      contract.address,
 			Balance:      big.NewInt(contract.balance),

--- a/vmhost/common.go
+++ b/vmhost/common.go
@@ -174,6 +174,7 @@ type VMHostParameters struct {
 	WasmerSIGSEGVPassthrough            bool
 	EpochNotifier                       vmcommon.EpochNotifier
 	EnableEpochsHandler                 vmcommon.EnableEpochsHandler
+	Hasher                              HashComputer
 	TimeOutForSCExecutionInMilliseconds uint32
 }
 

--- a/vmhost/contexts/async_test.go
+++ b/vmhost/contexts/async_test.go
@@ -75,8 +75,9 @@ func initializeVMAndWasmerAsyncContext() (*contextmock.VMHostMock, *worldmock.Mo
 		testVmType,
 		builtInFunctions.NewBuiltInFunctionContainer(),
 		exec,
+		defaultHasher,
 	)
-	runtimeCtx.instance = mockWasmerInstance
+	runtimeCtx.iTracker.instance = mockWasmerInstance
 	host.RuntimeContext = runtimeCtx
 
 	storageCtx, _ := NewStorageContext(host, world, reservedTestPrefix)

--- a/vmhost/contexts/blockchain_test.go
+++ b/vmhost/contexts/blockchain_test.go
@@ -203,7 +203,7 @@ func TestBlockchainContext_GetCodeHashAndSize(t *testing.T) {
 
 	address := []byte("account_with_code")
 	expectedCode := []byte("somecode")
-	expectedCodeHash, _ := defaultHasher.Compute(string(expectedCode))
+	expectedCodeHash := defaultHasher.Compute(string(expectedCode))
 
 	// GetCode: Test if error is propagated from blockchain hook
 	outputContext.OutputAccountIsNew = true

--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -1,0 +1,392 @@
+package contexts
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/multiversx/mx-chain-core-go/core/check"
+	"github.com/multiversx/mx-chain-core-go/storage/lrucache"
+	logger "github.com/multiversx/mx-chain-logger-go"
+	"github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-go/wasmer"
+)
+
+type instanceCacheLevel int
+
+const (
+	// Warm indicates that the instance to track is a warm instance
+	Warm instanceCacheLevel = iota
+
+	// Precompiled indicates that the instance to track is cold and has been created from precompiled code
+	Precompiled
+
+	// Bytecode indicates that the instance to track is cold and has been created from raw bytecode
+	Bytecode
+)
+
+var _ vmhost.StateStack = (*instanceTracker)(nil)
+
+var logTracker = logger.GetOrCreate("vm/tracker")
+
+type instanceTracker struct {
+	codeHash            []byte
+	numRunningInstances int
+	warmInstanceCache   Cacher
+	instance            wasmer.InstanceHandler
+	cacheLevel          instanceCacheLevel
+	instanceStack       []wasmer.InstanceHandler
+	codeHashStack       [][]byte
+
+	instances map[string]wasmer.InstanceHandler
+}
+
+// NewInstanceTracker creates a new instanceTracker instance
+func NewInstanceTracker() (*instanceTracker, error) {
+	tracker := &instanceTracker{
+		instances:           make(map[string]wasmer.InstanceHandler),
+		instanceStack:       make([]wasmer.InstanceHandler, 0),
+		numRunningInstances: 0,
+	}
+
+	var err error
+	instanceEvictedCallback := tracker.makeInstanceEvictionCallback()
+	if WarmInstancesEnabled {
+		tracker.warmInstanceCache, err = lrucache.NewCacheWithEviction(warmCacheSize, instanceEvictedCallback)
+	} else {
+		tracker.warmInstanceCache = nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return tracker, nil
+}
+
+// InitState initializes the internal instanceTracker state
+func (tracker *instanceTracker) InitState() {
+	tracker.numRunningInstances = 0
+	tracker.instance = nil
+	tracker.codeHash = make([]byte, 0)
+	tracker.instances = make(map[string]wasmer.InstanceHandler)
+}
+
+// PushState pushes the active instance and codeHash on the state stacks
+func (tracker *instanceTracker) PushState() {
+	tracker.instanceStack = append(tracker.instanceStack, tracker.instance)
+	tracker.codeHashStack = append(tracker.codeHashStack, tracker.codeHash)
+	logTracker.Trace("pushing instance", "id", tracker.instance.ID(), "codeHash", tracker.codeHash)
+}
+
+// PopSetActiveState pops the instance and codeHash from the state stacks and sets them as active
+func (tracker *instanceTracker) PopSetActiveState() {
+	instanceStackLen := len(tracker.instanceStack)
+	if instanceStackLen == 0 {
+		return
+	}
+
+	activeInstance := tracker.instance
+	activeCodeHash := tracker.codeHash
+	stackedPrevInstance := tracker.instanceStack[instanceStackLen-1]
+
+	onStack := tracker.IsCodeHashOnTheStack(activeCodeHash)
+	activeInstanceIsTopOfStack := stackedPrevInstance == activeInstance
+	cold := !WarmInstancesEnabled
+
+	if !activeInstanceIsTopOfStack && (onStack || cold) {
+		tracker.cleanPoppedInstance(activeInstance, activeCodeHash)
+	}
+
+	tracker.ReplaceInstance(stackedPrevInstance)
+
+	tracker.instanceStack = tracker.instanceStack[:instanceStackLen-1]
+	tracker.codeHash = tracker.codeHashStack[instanceStackLen-1]
+	tracker.codeHashStack = tracker.codeHashStack[:instanceStackLen-1]
+}
+
+func (tracker *instanceTracker) cleanPoppedInstance(instance wasmer.InstanceHandler, codeHash []byte) {
+	if !check.IfNil(instance) {
+		if instance.Clean() {
+			tracker.updateNumRunningInstances(-1)
+		}
+
+		logTracker.Trace("clean popped instance", "id", instance.ID(), "codeHash", codeHash)
+	}
+}
+
+// PopDiscard does nothing for the instanceTracker
+func (tracker *instanceTracker) PopDiscard() {
+}
+
+// ClearStateStack reinitializes the state stack.
+func (tracker *instanceTracker) ClearStateStack() {
+	tracker.codeHashStack = make([][]byte, 0)
+	tracker.instanceStack = make([]wasmer.InstanceHandler, 0)
+}
+
+// StackSize returns the size of the instance stack
+func (tracker *instanceTracker) StackSize() uint64 {
+	return uint64(len(tracker.instanceStack))
+}
+
+// Instance returns the active instance
+func (tracker *instanceTracker) Instance() wasmer.InstanceHandler {
+	return tracker.instance
+}
+
+// GetWarmInstance retrieves a warm instance from the internal cache
+func (tracker *instanceTracker) GetWarmInstance(codeHash []byte) (wasmer.InstanceHandler, bool) {
+	cachedObject, ok := tracker.warmInstanceCache.Get(codeHash)
+	if !ok {
+		return nil, false
+	}
+
+	instance, ok := cachedObject.(wasmer.InstanceHandler)
+	if !ok {
+		return nil, false
+	}
+
+	return instance, true
+}
+
+// CodeHash returns the codeHash of the active instance
+func (tracker *instanceTracker) CodeHash() []byte {
+	return tracker.codeHash
+}
+
+// ClearWarmInstanceCache clears the internal warm instance cache
+func (tracker *instanceTracker) ClearWarmInstanceCache() {
+	if WarmInstancesEnabled {
+		tracker.warmInstanceCache.Clear()
+	}
+}
+
+// UseWarmInstance attempts to retrieve a warm instance for the given codeHash
+// and to set it as active; returns false if not possible
+func (tracker *instanceTracker) UseWarmInstance(codeHash []byte, newCode bool) bool {
+	instance, ok := tracker.GetWarmInstance(codeHash)
+	if !ok {
+		return false
+	}
+
+	ok = instance.Reset()
+	if !ok {
+		tracker.warmInstanceCache.Remove(codeHash)
+		return false
+	}
+
+	if newCode {
+		// A warm instance was found, but newCode == true, meaning this is an
+		// upgrade; the old warm instance must be cleaned
+		tracker.ForceCleanInstance(false)
+		return false
+	}
+
+	tracker.SetNewInstance(instance, Warm)
+	return true
+}
+
+// ForceCleanInstance cleans the active instance and evicts it from the
+// internal warm instance cache if possible
+func (tracker *instanceTracker) ForceCleanInstance(bypassWarmAndStackChecks bool) {
+	if check.IfNil(tracker.instance) {
+		logTracker.Trace("cannot clean, instance already nil")
+		return
+	}
+
+	defer func() {
+		tracker.UnsetInstance()
+		numWarmInstances, numColdInstances := tracker.NumRunningInstances()
+		logTracker.Trace("instance cleaned; num instances", "warm", numWarmInstances, "cold", numColdInstances)
+	}()
+
+	if bypassWarmAndStackChecks {
+		if tracker.instance.Clean() {
+			tracker.updateNumRunningInstances(-1)
+		}
+
+		return
+	}
+
+	onStack := tracker.IsCodeHashOnTheStack(tracker.codeHash)
+	coldOnlyEnabled := !WarmInstancesEnabled
+	if onStack || coldOnlyEnabled {
+		if tracker.instance.Clean() {
+			tracker.updateNumRunningInstances(-1)
+		}
+	} else {
+		tracker.warmInstanceCache.Remove(tracker.codeHash)
+	}
+}
+
+// SaveAsWarmInstance saves the active instance into the internal warm instance cache
+func (tracker *instanceTracker) SaveAsWarmInstance() {
+	lenCacheBeforeSaving := tracker.warmInstanceCache.Len()
+
+	codeHashInWarmCache := tracker.warmInstanceCache.Has(tracker.codeHash)
+
+	if codeHashInWarmCache {
+		// Finding an instance in the warm cache at this point means that
+		// context.instance is a new instance which must replace the one in the
+		// warm cache, because they have the same bytecode. The old one is removed
+		// and cleaned before the new one is added to the cache.
+		logTracker.Trace("warm instance already in cache, evicting",
+			"id", tracker.instance.ID(),
+			"codeHash", tracker.codeHash)
+		tracker.warmInstanceCache.Remove(tracker.codeHash)
+	}
+
+	logTracker.Trace("warm instance not found, saving",
+		"id", tracker.instance.ID(),
+		"codeHash", tracker.codeHash,
+	)
+	tracker.warmInstanceCache.Put(
+		tracker.codeHash,
+		tracker.instance,
+		1,
+	)
+
+	lenCacheAfterSaving := tracker.warmInstanceCache.Len()
+	logTracker.Trace("after saving, warm instance size",
+		"before", lenCacheBeforeSaving,
+		"after", lenCacheAfterSaving,
+	)
+
+	logTracker.Trace("save warm instance",
+		"id", tracker.instance.ID(),
+		"codeHash", tracker.codeHash,
+	)
+}
+
+// SetCodeHash sets the active codeHash; it must correspond with the active instance
+func (tracker *instanceTracker) SetCodeHash(codeHash []byte) {
+	tracker.codeHash = codeHash
+}
+
+// SetNewInstance sets the given instance as active and tracks its creation
+func (tracker *instanceTracker) SetNewInstance(instance wasmer.InstanceHandler, cacheLevel instanceCacheLevel) {
+	tracker.ReplaceInstance(instance)
+	tracker.cacheLevel = cacheLevel
+	if cacheLevel != Warm {
+		tracker.updateNumRunningInstances(+1)
+	}
+	tracker.instances[instance.ID()] = instance
+}
+
+// ReplaceInstance replaces the currently active instance with the given one
+func (tracker *instanceTracker) ReplaceInstance(instance wasmer.InstanceHandler) {
+	var previousInstanceID string
+	if check.IfNil(tracker.instance) {
+		logTracker.Trace("ReplaceInstance: previous instance was nil")
+		previousInstanceID = "nil"
+	} else {
+		previousInstanceID = tracker.instance.ID()
+	}
+
+	logTracker.Trace("replaced instance",
+		"prev id", previousInstanceID,
+		"new id", instance.ID())
+	tracker.instance = instance
+}
+
+// UnsetInstance replaces the currently active instance with nil
+func (tracker *instanceTracker) UnsetInstance() {
+	if check.IfNil(tracker.instance) {
+		logTracker.Trace("UnsetInstance: current instance is already nil")
+		return
+	}
+
+	logTracker.Trace("UnsetInstance",
+		"id", tracker.instance.ID(),
+		"codeHash", tracker.codeHash)
+	tracker.instance = nil
+	tracker.codeHash = nil
+
+}
+
+// LogCounts prints the instance counter to the log
+func (tracker *instanceTracker) LogCounts() {
+	warm, cold := tracker.NumRunningInstances()
+	logTracker.Trace("num instances after starting new one",
+		"warm", warm,
+		"cold", cold,
+		"total", tracker.numRunningInstances,
+	)
+}
+
+// NumRunningInstances returns the number of currently running instances (cold and warm)
+func (tracker *instanceTracker) NumRunningInstances() (int, int) {
+	numWarmInstances := 0
+	if WarmInstancesEnabled {
+		numWarmInstances = tracker.warmInstanceCache.Len()
+	}
+
+	numColdInstances := tracker.numRunningInstances - numWarmInstances
+	return numWarmInstances, numColdInstances
+}
+
+// IsCodeHashOnTheStack returns true if the given codeHash is found on the codeHash stack
+func (tracker *instanceTracker) IsCodeHashOnTheStack(codeHash []byte) bool {
+	for _, stackedCodeHash := range tracker.codeHashStack {
+		if bytes.Equal(codeHash, stackedCodeHash) {
+			return true
+		}
+	}
+	return false
+}
+
+// CheckInstances returns an error if there are tracked cold instances which
+// have not been cleaned (leak detection)
+func (tracker *instanceTracker) CheckInstances() error {
+	unclosedWarm := 0
+	unclosedCold := 0
+
+	warmInstanceCacheByID := make(map[string]wasmer.InstanceHandler)
+	for _, key := range tracker.warmInstanceCache.Keys() {
+		instance, ok := tracker.GetWarmInstance(key)
+		if !ok {
+			return fmt.Errorf("degenerate cache")
+		}
+		warmInstanceCacheByID[instance.ID()] = instance
+	}
+
+	for id, instance := range tracker.instances {
+		if instance.AlreadyCleaned() {
+			continue
+		}
+		_, isWarm := warmInstanceCacheByID[id]
+		if isWarm {
+			unclosedWarm++
+		} else {
+			unclosedCold++
+			logTracker.Trace("unclosed cold instance", "id", id)
+		}
+	}
+
+	if unclosedCold != 0 {
+		return fmt.Errorf(
+			"unclosed cold instances remaining: cold %d, warm %d",
+			unclosedCold,
+			unclosedWarm)
+	}
+
+	return nil
+}
+
+func (tracker *instanceTracker) makeInstanceEvictionCallback() func(interface{}, interface{}) {
+	return func(_ interface{}, value interface{}) {
+		instance, ok := value.(wasmer.InstanceHandler)
+		if !ok {
+			return
+		}
+
+		logTracker.Trace("evicted instance", "id", instance.ID())
+		if instance.Clean() {
+			tracker.updateNumRunningInstances(-1)
+		}
+	}
+}
+
+func (tracker *instanceTracker) updateNumRunningInstances(delta int) {
+	tracker.numRunningInstances += delta
+	logTracker.Trace("num running instances updated", "delta", delta)
+}

--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -11,6 +11,8 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/vmhost"
 )
 
+var _ vmhost.InstanceTracker = (*instanceTracker)(nil)
+
 type instanceCacheLevel int
 
 const (
@@ -158,6 +160,11 @@ func (tracker *instanceTracker) ClearWarmInstanceCache() {
 	if WarmInstancesEnabled {
 		tracker.warmInstanceCache.Clear()
 	}
+}
+
+// TrackedInstances returns the internal map of tracked instances
+func (tracker *instanceTracker) TrackedInstances() map[string]executor.Instance {
+	return tracker.instances
 }
 
 // UseWarmInstance attempts to retrieve a warm instance for the given codeHash

--- a/vmhost/contexts/instanceTracker_test.go
+++ b/vmhost/contexts/instanceTracker_test.go
@@ -13,7 +13,7 @@ func TestInstanceTracker_TrackInstance(t *testing.T) {
 	iTracker, err := NewInstanceTracker()
 	require.Nil(t, err)
 
-	newInstance := &wasmer.Instance{
+	newInstance := &wasmer.WasmerInstance{
 		AlreadyClean: false,
 	}
 
@@ -292,7 +292,7 @@ func TestInstanceTracker_UnsetInstance_Ok(t *testing.T) {
 	iTracker, err := NewInstanceTracker()
 	require.Nil(t, err)
 
-	iTracker.instance = &wasmer.Instance{
+	iTracker.instance = &wasmer.WasmerInstance{
 		AlreadyClean: true,
 	}
 	iTracker.UnsetInstance()

--- a/vmhost/contexts/instanceTracker_test.go
+++ b/vmhost/contexts/instanceTracker_test.go
@@ -1,0 +1,316 @@
+package contexts
+
+import (
+	"strings"
+	"testing"
+
+	mock "github.com/multiversx/mx-chain-vm-go/mock/context"
+	"github.com/multiversx/mx-chain-vm-go/wasmer"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInstanceTracker_TrackInstance(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	newInstance := &wasmer.Instance{
+		AlreadyClean: false,
+	}
+
+	iTracker.SetNewInstance(newInstance, Bytecode)
+	iTracker.codeHash = []byte("testinst")
+
+	require.False(t, iTracker.IsCodeHashOnTheStack(iTracker.codeHash))
+
+	require.Equal(t, newInstance, iTracker.instance)
+	require.Equal(t, Bytecode, iTracker.cacheLevel)
+
+	iTracker.SaveAsWarmInstance()
+
+	warm, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 1, warm)
+	require.Equal(t, 0, cold)
+}
+
+func TestInstanceTracker_InitState(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	for i := 0; i < 5; i++ {
+		iTracker.SetNewInstance(mock.NewInstanceMock(nil), Bytecode)
+	}
+
+	require.Equal(t, 5, iTracker.numRunningInstances)
+	require.Len(t, iTracker.instances, 5)
+
+	iTracker.InitState()
+
+	require.Nil(t, iTracker.instance)
+	require.Equal(t, 0, iTracker.numRunningInstances)
+	require.Len(t, iTracker.codeHash, 0)
+	require.Len(t, iTracker.instances, 0)
+}
+
+func TestInstanceTracker_GetWarmInstance(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"warm1", "bytecode1", "bytecode2", "warm2"}
+
+	for _, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+		if strings.Contains(codeHash, "warm") {
+			iTracker.SaveAsWarmInstance()
+		}
+	}
+
+	require.Equal(t, 4, iTracker.numRunningInstances)
+	require.Len(t, iTracker.instances, 4)
+
+	for _, codeHash := range testData {
+		instance, ok := iTracker.GetWarmInstance([]byte(codeHash))
+
+		if strings.Contains(codeHash, "warm") {
+			require.NotNil(t, instance)
+			require.True(t, ok)
+			continue
+		}
+
+		require.Nil(t, instance)
+		require.False(t, ok)
+	}
+
+}
+
+func TestInstanceTracker_UserWarmInstance(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"warm1", "bytecode1", "warm2", "bytecode2"}
+
+	for _, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+
+		if strings.Contains(codeHash, "warm") {
+			iTracker.SaveAsWarmInstance()
+		}
+	}
+
+	require.Equal(t, []byte("bytecode2"), iTracker.CodeHash())
+
+	for _, codeHash := range testData {
+		ok := iTracker.UseWarmInstance([]byte(codeHash), false)
+
+		if strings.Contains(codeHash, "warm") {
+			require.True(t, ok)
+			continue
+		}
+
+		require.False(t, ok)
+	}
+}
+
+// stack: alpha<-alpha(cold)<-alpha(cold)<-alpha(cold)
+func TestInstancetracker_PopSetActiveSelfScenario(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"alpha", "alpha", "alpha", "alpha", "active"}
+
+	for i, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+		if i == 0 || codeHash == "active" {
+			iTracker.SaveAsWarmInstance()
+		}
+		if codeHash != "active" {
+			iTracker.PushState()
+		}
+	}
+	require.Len(t, iTracker.codeHashStack, 4)
+	require.Len(t, iTracker.instanceStack, 4)
+
+	warm, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 2, warm)
+	require.Equal(t, 3, cold)
+
+	checkColdInstancesAfterEmptyingStack(t, iTracker)
+
+	iTracker.ClearWarmInstanceCache()
+	checkInstances(t, iTracker)
+}
+
+// stack: alpha<-beta<-alpha(cold)<-beta(cold)
+func TestInstancetracker_PopSetActiveSimpleScenario(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"alpha", "beta", "alpha", "beta", "active"}
+
+	for i, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+		if i < 2 || codeHash == "active" {
+			iTracker.SaveAsWarmInstance()
+		}
+		if codeHash != "active" {
+			iTracker.PushState()
+		}
+	}
+	require.Len(t, iTracker.codeHashStack, 4)
+	require.Len(t, iTracker.instanceStack, 4)
+
+	warm, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 3, warm)
+	require.Equal(t, 2, cold)
+
+	checkColdInstancesAfterEmptyingStack(t, iTracker)
+
+	iTracker.ClearWarmInstanceCache()
+	checkInstances(t, iTracker)
+}
+
+// stack: alpha<-beta<-gamma<-beta(cold)<-gamma(cold)<-delta<-alpha(cold)
+func TestInstancetracker_PopSetActiveComplexSecanario(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"alpha", "beta", "gamma", "beta", "gamma", "delta", "alpha", "active"}
+
+	for i, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+		if i < 3 || codeHash == "delta" || codeHash == "active" {
+			iTracker.SaveAsWarmInstance()
+		}
+		if codeHash != "active" {
+			iTracker.PushState()
+		}
+	}
+	require.Len(t, iTracker.codeHashStack, 7)
+	require.Len(t, iTracker.instanceStack, 7)
+
+	warm, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 5, warm)
+	require.Equal(t, 3, cold)
+
+	checkColdInstancesAfterEmptyingStack(t, iTracker)
+
+	iTracker.ClearWarmInstanceCache()
+	checkInstances(t, iTracker)
+}
+
+func TestInstanceTracker_PopSetActiveWarmOnlyScenario(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"alpha", "beta", "gamma", "delta", "active"}
+
+	for _, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+		iTracker.SaveAsWarmInstance()
+
+		if codeHash != "active" {
+			iTracker.PushState()
+		}
+	}
+	require.Len(t, iTracker.codeHashStack, 4)
+	require.Len(t, iTracker.instanceStack, 4)
+
+	warm, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 5, warm)
+	require.Equal(t, 0, cold)
+
+	checkColdInstancesAfterEmptyingStack(t, iTracker)
+
+	iTracker.ClearWarmInstanceCache()
+	checkInstances(t, iTracker)
+}
+
+func TestInstanceTracker_ForceCleanInstanceWithBypass(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	testData := []string{"warm1", "bytecode1"}
+
+	for _, codeHash := range testData {
+		iTracker.SetNewInstance(mock.NewInstanceMock([]byte(codeHash)), Bytecode)
+		iTracker.codeHash = []byte(codeHash)
+
+		if strings.Contains(codeHash, "warm") {
+			iTracker.SaveAsWarmInstance()
+		}
+	}
+
+	warm, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 1, warm)
+	require.Equal(t, 1, cold)
+
+	iTracker.ForceCleanInstance(true)
+	require.Nil(t, iTracker.instance)
+
+	iTracker.UseWarmInstance([]byte("warm1"), false)
+	require.NotNil(t, iTracker.instance)
+
+	iTracker.ForceCleanInstance(true)
+	require.Nil(t, iTracker.instance)
+
+	require.Equal(t, 0, iTracker.numRunningInstances)
+	require.Nil(t, iTracker.CheckInstances())
+}
+
+func TestInstanceTracker_DoubleForceClean(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	iTracker.SetNewInstance(mock.NewInstanceMock(nil), Bytecode)
+	require.NotNil(t, iTracker.instance)
+	require.Equal(t, 1, iTracker.numRunningInstances)
+
+	iTracker.ForceCleanInstance(true)
+	require.Equal(t, 0, iTracker.numRunningInstances)
+	require.Nil(t, iTracker.CheckInstances())
+
+	iTracker.ForceCleanInstance(true)
+	require.Equal(t, 0, iTracker.numRunningInstances)
+	require.Nil(t, iTracker.CheckInstances())
+}
+
+func TestInstanceTracker_UnsetInstance_AlreadyNil_Ok(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	iTracker.instance = nil
+	iTracker.UnsetInstance()
+	require.Nil(t, iTracker.instance)
+}
+
+func TestInstanceTracker_UnsetInstance_Ok(t *testing.T) {
+	iTracker, err := NewInstanceTracker()
+	require.Nil(t, err)
+
+	iTracker.instance = &wasmer.Instance{
+		AlreadyClean: true,
+	}
+	iTracker.UnsetInstance()
+	require.Nil(t, iTracker.instance)
+}
+
+func checkColdInstancesAfterEmptyingStack(t *testing.T, iTracker *instanceTracker) {
+	n := len(iTracker.instanceStack)
+	for i := 0; i < n; i++ {
+		iTracker.PopSetActiveState()
+	}
+	_, cold := iTracker.NumRunningInstances()
+	require.Equal(t, 0, cold)
+}
+
+func checkInstances(t *testing.T, iTracker *instanceTracker) {
+	require.Equal(t, 0, iTracker.numRunningInstances)
+	require.Len(t, iTracker.instanceStack, 0)
+	require.Len(t, iTracker.codeHashStack, 0)
+	require.Nil(t, iTracker.CheckInstances())
+}

--- a/vmhost/contexts/runtime.go
+++ b/vmhost/contexts/runtime.go
@@ -123,6 +123,11 @@ func (context *runtimeContext) ReplaceVMExecutor(vmExecutor executor.Executor) {
 	context.vmExecutor = vmExecutor
 }
 
+// GetInstanceTracker returns the internal instance tracker
+func (context *runtimeContext) GetInstanceTracker() vmhost.InstanceTracker {
+	return context.iTracker
+}
+
 // StartWasmerInstance creates a new wasmer instance if the maxInstanceStackSize has not been reached.
 func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uint64, newCode bool) error {
 	context.iTracker.UnsetInstance()
@@ -748,7 +753,7 @@ func (context *runtimeContext) CountSameContractInstancesOnStack(address []byte)
 	count := uint64(0)
 	for _, state := range context.stateStack {
 		if bytes.Equal(address, state.vmInput.RecipientAddr) {
-			count += 1
+			count++
 		}
 	}
 

--- a/vmhost/errors.go
+++ b/vmhost/errors.go
@@ -7,8 +7,17 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/executor"
 )
 
+// ErrNilVMType signals that the provided VMType is nil
+var ErrNilVMType = errors.New("nil VMType")
+
 // ErrNilVMHost signals that the provided VMHost is nil
 var ErrNilVMHost = errors.New("nil VMHost")
+
+// ErrNilExecutor signals that the provided Executor is nil
+var ErrNilExecutor = errors.New("nil Executor")
+
+// ErrNilHasher signals that the provided Hasher is nil
+var ErrNilHasher = errors.New("nil Hasher")
 
 // ErrReturnCodeNotOk signals that the returned code is different than vmcommon.Ok
 var ErrReturnCodeNotOk = errors.New("return code is not ok")

--- a/vmhost/hostCore/execution.go
+++ b/vmhost/hostCore/execution.go
@@ -176,7 +176,7 @@ func (host *vmHost) checkGasForGetCode(input *vmcommon.ContractCallInput, meteri
 	return nil
 }
 
-// doRunSmartContractDelete delete a contract directly
+// doRunSmartContractDelete deletes a contract directly
 func (host *vmHost) doRunSmartContractDelete(input *vmcommon.ContractCallInput) *vmcommon.VMOutput {
 	output := host.Output()
 	err := host.checkUpgradePermission(input)

--- a/vmhost/hostCore/execution.go
+++ b/vmhost/hostCore/execution.go
@@ -93,6 +93,12 @@ func (host *vmHost) performCodeDeployment(input vmhost.CodeDeployInput) (*vmcomm
 		return nil, vmhost.ErrContractInvalid
 	}
 
+	defer func() {
+		if !contexts.WarmInstancesEnabled {
+			runtime.CleanInstance()
+		}
+	}()
+
 	err = host.callInitFunction()
 	if err != nil {
 		return nil, err
@@ -240,6 +246,12 @@ func (host *vmHost) doRunSmartContractCall(input *vmcommon.ContractCallInput) *v
 		vmOutput = output.CreateVMOutputInCaseOfError(vmhost.ErrContractInvalid)
 		return vmOutput
 	}
+
+	defer func() {
+		if !contexts.WarmInstancesEnabled {
+			runtime.CleanInstance()
+		}
+	}()
 
 	err = host.callSCMethod()
 	if err != nil {

--- a/vmhost/hostCore/host_test.go
+++ b/vmhost/hostCore/host_test.go
@@ -1,0 +1,86 @@
+package hostCore
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
+	"github.com/multiversx/mx-chain-vm-common-go/parsers"
+	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
+	"github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVMHost(t *testing.T) {
+	blockchainHook := worldmock.NewMockWorld()
+	bfc := builtInFunctions.NewBuiltInFunctionContainer()
+	epochNotifier := &mock.EpochNotifierStub{}
+	epochsHandler := &worldmock.EnableEpochsHandlerStub{}
+	vmType := []byte("vmType")
+	esdtTransferParser, err := parsers.NewESDTTransferParser(worldmock.WorldMarshalizer)
+	require.Nil(t, err)
+
+	makeHostParameters := func() *vmhost.VMHostParameters {
+		return &vmhost.VMHostParameters{
+			VMType:               vmType,
+			ESDTTransferParser:   esdtTransferParser,
+			BuiltInFuncContainer: bfc,
+			EpochNotifier:        epochNotifier,
+			EnableEpochsHandler:  epochsHandler,
+			Hasher:               worldmock.DefaultHasher,
+		}
+	}
+
+	t.Run("NilBlockchainHook", func(t *testing.T) {
+		host, err := NewVMHost(nil, makeHostParameters())
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilBlockChainHook)
+	})
+	t.Run("NilHostParameters", func(t *testing.T) {
+		host, err := NewVMHost(blockchainHook, nil)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilHostParameters)
+	})
+	t.Run("NilESDTTransferParser", func(t *testing.T) {
+		hostParameters := makeHostParameters()
+		hostParameters.ESDTTransferParser = nil
+		host, err := NewVMHost(blockchainHook, hostParameters)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilESDTTransferParser)
+	})
+	t.Run("NilBuiltInFunctionsContainer", func(t *testing.T) {
+		hostParameters := makeHostParameters()
+		hostParameters.BuiltInFuncContainer = nil
+		host, err := NewVMHost(blockchainHook, hostParameters)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilBuiltInFunctionsContainer)
+	})
+	t.Run("NilEpochNotifier", func(t *testing.T) {
+		hostParameters := makeHostParameters()
+		hostParameters.EpochNotifier = nil
+		host, err := NewVMHost(blockchainHook, hostParameters)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilEpochNotifier)
+	})
+	t.Run("NilEnableEpochsHandler", func(t *testing.T) {
+		hostParameters := makeHostParameters()
+		hostParameters.EnableEpochsHandler = nil
+		host, err := NewVMHost(blockchainHook, hostParameters)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilEnableEpochsHandler)
+	})
+	t.Run("NilHasher", func(t *testing.T) {
+		hostParameters := makeHostParameters()
+		hostParameters.Hasher = nil
+		host, err := NewVMHost(blockchainHook, hostParameters)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilHasher)
+	})
+	t.Run("NilVMType", func(t *testing.T) {
+		hostParameters := makeHostParameters()
+		hostParameters.VMType = nil
+		host, err := NewVMHost(blockchainHook, hostParameters)
+		require.Nil(t, host)
+		require.ErrorIs(t, err, vmhost.ErrNilVMType)
+	})
+}

--- a/vmhost/hosttest/execution_test.go
+++ b/vmhost/hosttest/execution_test.go
@@ -957,7 +957,6 @@ func buildRandomizer(host vmhost.VMHost) io.Reader {
 }
 
 func TestExecution_ManagedBuffers_SetByteSlice(t *testing.T) {
-	// mByteSetByteSlice not yet enabled
 	runTestMBufferSetByteSliceDeploy(t, true, vmcommon.Ok)
 
 	// Correct copying from "ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890" over "abcdefghijklmnopqrstuvwxyz"
@@ -2240,7 +2239,7 @@ func TestExecution_ExecuteOnDestContext_Recursive_Mutual_SCs(t *testing.T) {
 		storeEntries = append(storeEntries, test.CreateStoreEntry(test.ChildAddress).WithKey(test.RecursiveIterationBigCounterKey).WithValue(big.NewInt(int64(1)).Bytes()))
 	}
 
-	test.BuildInstanceCallTest(t).
+	testCase := test.BuildInstanceCallTest(t).
 		WithContracts(
 			test.CreateInstanceContract(test.ParentAddress).
 				WithCode(test.GetTestSCCode("exec-dest-ctx-recursive-parent", "../../")).
@@ -2254,8 +2253,10 @@ func TestExecution_ExecuteOnDestContext_Recursive_Mutual_SCs(t *testing.T) {
 			WithFunction(parentCallsChild).
 			WithGasProvided(test.GasProvided).
 			WithArguments([]byte{byte(recursiveCalls)}).
-			Build()).
-		AndAssertResults(func(host vmhost.VMHost, stubBlockchainHook *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
+			Build())
+
+	for i := 0; i < 1; i++ {
+		testCase.AndAssertResultsWithoutReset(func(host vmhost.VMHost, stubBlockchainHook *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
 			verify.Ok().
 				// test.ParentAddress
 				Balance(test.ParentAddress, 1000).
@@ -2270,12 +2271,10 @@ func TestExecution_ExecuteOnDestContext_Recursive_Mutual_SCs(t *testing.T) {
 				Storage(storeEntries...)
 
 			require.Equal(t, int64(1), host.ManagedTypes().GetBigIntOrCreate(88).Int64())
-
-			// Check remaining instances count
-			numWarmInstances, numColdInstances := host.Runtime().NumRunningInstances()
-			require.Equal(t, 0, numColdInstances, "cold instances still running")
-			require.Equal(t, 2, numWarmInstances, "warm instances still running")
 		})
+	}
+
+	_ = testCase.GetVMHost().Close()
 }
 
 func TestExecution_ExecuteOnDestContext_Recursive_Mutual_SCs_OutOfGas(t *testing.T) {
@@ -2407,7 +2406,7 @@ func TestExecution_ExecuteOnDestContextByCaller_SimpleTransfer(t *testing.T) {
 	// many as requested. The parent calls the child using
 	// executeOnDestContextByCaller(), which means that the child will not see
 	// the parent as its caller, but the original caller of the transaction
-	// instead. Thus the original caller (the user address) will receive 42
+	// instead. Thus, the original caller (the user address) will receive 42
 	// tokens, and not the parent, even if the parent is the one making the call
 	// to the child.
 
@@ -3169,7 +3168,7 @@ func TestExecution_Mocked_Warm_Instances_Same_Contract_Different_Address(t *test
 		AndAssertResults(func(world *worldmock.MockWorld, verify *test.VMOutputVerifier) {
 			verify.OutOfGas()
 		})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 func TestExecution_Mocked_ClearReturnData(t *testing.T) {
@@ -3273,7 +3272,7 @@ func TestExecution_Mocked_ClearReturnData(t *testing.T) {
 		AndAssertResults(func(world *worldmock.MockWorld, verify *test.VMOutputVerifier) {
 			// No assertions here, because they were performed during the instance call
 		})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 var codeOpcodes = test.GetTestSCCode("opcodes", "../../")
@@ -3495,7 +3494,7 @@ func TestExecution_Mocked_OnSameFollowedByOnDest(t *testing.T) {
 			verify.Ok().
 				ReturnData([]byte("parent returns this"), []byte("child returns this"), []byte("newphew returns this"), []byte("OK"))
 		})
-	assert.Nil(t, err)
+	require.Nil(t, err)
 }
 
 // makeBytecodeWithLocals rewrites the bytecode of "answer" to change the

--- a/vmhost/hosttest/wasmer_test.go
+++ b/vmhost/hosttest/wasmer_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/multiversx/mx-chain-vm-go/executor"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
 	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
 	test "github.com/multiversx/mx-chain-vm-go/testcommon"
@@ -252,7 +253,7 @@ func TestWASMMemories_ResetContent(t *testing.T) {
 
 	assertFunc := func(host vmhost.VMHost, _ *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
 		verify.Ok().ReturnData([]byte(keyword))
-		instance := host.Runtime().GetInstance()
+		instance := extractSingleTrackedInstanceFromHost(verify.T, host)
 		require.NotNil(verify.T, instance)
 		memory := instance.MemDump()
 		require.Len(verify.T, memory, 1*vmhost.WASMPageSize)
@@ -278,8 +279,10 @@ func TestWASMMemories_ResetDataInitializers(t *testing.T) {
 
 	assertFunc := func(host vmhost.VMHost, _ *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
 		verify.Ok().ReturnData([]byte(keyword))
-		instance := host.Runtime().GetInstance()
+
+		instance := extractSingleTrackedInstanceFromHost(verify.T, host)
 		require.NotNil(verify.T, instance)
+
 		memory := instance.MemDump()
 		require.Len(verify.T, memory, 1*vmhost.WASMPageSize)
 		require.Equal(verify.T, keyword, string(memory[keywordOffset:keywordOffset+len(keyword)]))
@@ -346,4 +349,15 @@ func TestWASMCreateAndCall(t *testing.T) {
 		verify = test.NewVMOutputVerifier(t, vmOutput, err)
 		verify.Ok()
 	}
+}
+
+func extractSingleTrackedInstanceFromHost(tb testing.TB, host vmhost.VMHost) executor.Instance {
+	trackedInstances := host.Runtime().GetInstanceTracker().TrackedInstances()
+	require.Len(tb, trackedInstances, 1)
+
+	for _, inst := range trackedInstances {
+		return inst
+	}
+
+	return nil
 }

--- a/vmhost/interface.go
+++ b/vmhost/interface.go
@@ -136,6 +136,7 @@ type RuntimeContext interface {
 	SetMaxInstanceStackSize(uint64)
 	VerifyContractCode() error
 	GetInstance() executor.Instance
+	GetInstanceTracker() InstanceTracker
 	FunctionNameChecked() (string, error)
 	CallSCFunction(functionName string) error
 	GetPointsUsed() uint64
@@ -156,6 +157,13 @@ type RuntimeContext interface {
 	GetPrevTxHash() []byte
 	EndExecution()
 	ValidateInstances() error
+}
+
+// InstanceTracker defines the functionality needed for interacting with the instance tracker
+type InstanceTracker interface {
+	StateStack
+
+	TrackedInstances() map[string]executor.Instance
 }
 
 // ManagedTypesContext defines the functionality needed for interacting with the big int context

--- a/vmhost/interface.go
+++ b/vmhost/interface.go
@@ -147,7 +147,6 @@ type RuntimeContext interface {
 	BigFloatAPIErrorShouldFailExecution() bool
 	ManagedBufferAPIErrorShouldFailExecution() bool
 	CleanInstance()
-	NumRunningInstances() (int, int)
 
 	AddError(err error, otherInfo ...string)
 	GetAllErrors() error
@@ -155,6 +154,8 @@ type RuntimeContext interface {
 	ValidateCallbackName(callbackName string) error
 	HasFunction(functionName string) bool
 	GetPrevTxHash() []byte
+	EndExecution()
+	ValidateInstances() error
 }
 
 // ManagedTypesContext defines the functionality needed for interacting with the big int context
@@ -400,5 +401,12 @@ type GasTracing interface {
 	AddToCurrentTrace(usedGas uint64)
 	AddTracedGas(scAddress string, functionName string, usedGas uint64)
 	GetGasTrace() map[string]map[string][]uint64
+	IsInterfaceNil() bool
+}
+
+// HashComputer provides hash computation
+type HashComputer interface {
+	Compute(string) []byte
+	Size() int
 	IsInterfaceNil() bool
 }

--- a/vmserver/world.go
+++ b/vmserver/world.go
@@ -3,6 +3,7 @@ package vmserver
 import (
 	"math/big"
 
+	"github.com/multiversx/mx-chain-core-go/hashing/blake2b"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/multiversx/mx-chain-vm-common-go/parsers"
@@ -12,6 +13,8 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/vmhost/hostCore"
 	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
 )
+
+var defaultHasher = blake2b.NewBlake2b()
 
 type worldDataModel struct {
 	ID       string
@@ -64,6 +67,7 @@ func getHostParameters() *vmhost.VMHostParameters {
 		EpochNotifier:            &mock.EpochNotifierStub{},
 		EnableEpochsHandler:      worldmock.EnableEpochsHandlerStubNoFlags(),
 		WasmerSIGSEGVPassthrough: false,
+		Hasher:                   defaultHasher,
 	}
 }
 

--- a/wasmer/wasmerExecutor.go
+++ b/wasmer/wasmerExecutor.go
@@ -67,3 +67,8 @@ func (wasmerExecutor *WasmerExecutor) initVMHooks(vmHooks executor.VMHooks) {
 	wasmerExecutor.vmHooks = vmHooks
 	wasmerExecutor.vmHooksPtr = uintptr(unsafe.Pointer(&wasmerExecutor.vmHooks))
 }
+
+// IsInterfaceNil returns true if there is no value under the interface
+func (wasmerExecutor *WasmerExecutor) IsInterfaceNil() bool {
+	return wasmerExecutor == nil
+}

--- a/wasmer/wasmerInstance.go
+++ b/wasmer/wasmerInstance.go
@@ -68,7 +68,7 @@ type WasmerInstance struct {
 	// The underlying WebAssembly instance.
 	instance *cWasmerInstanceT
 
-	alreadyCleaned bool
+	AlreadyClean bool
 
 	// All functions exported by the WebAssembly instance, indexed
 	// by their name as a string. An exported function is a
@@ -202,11 +202,11 @@ func NewInstanceFromCompiledCodeWithOptions(
 }
 
 // Clean cleans instance
-func (instance *WasmerInstance) Clean() {
-	logWasmer.Trace("cleaning instance", "id", instance.Id())
-	if instance.alreadyCleaned {
-		logWasmer.Trace("clean: already cleaned instance", "id", instance.Id())
-		return
+func (instance *WasmerInstance) Clean() bool {
+	logWasmer.Trace("cleaning instance", "id", instance.ID())
+	if instance.AlreadyClean {
+		logWasmer.Trace("clean: already cleaned instance", "id", instance.ID())
+		return false
 	}
 
 	if instance.instance != nil {
@@ -216,10 +216,18 @@ func (instance *WasmerInstance) Clean() {
 			instance.Memory.Destroy()
 		}
 
-		instance.alreadyCleaned = true
-		logWasmer.Trace("cleaned instance", "id", instance.Id())
+		instance.AlreadyClean = true
+		logWasmer.Trace("cleaned instance", "id", instance.ID())
 
+		return true
 	}
+
+	return false
+}
+
+// AlreadyCleaned returns the internal field AlreadyClean
+func (instance *WasmerInstance) AlreadyCleaned() bool {
+	return instance.AlreadyClean
 }
 
 // GetPointsUsed returns the internal instance gas counter
@@ -337,15 +345,15 @@ func (instance *WasmerInstance) MemDump() []byte {
 
 // Reset resets the instance memories and globals
 func (instance *WasmerInstance) Reset() bool {
-	if instance.alreadyCleaned {
-		logWasmer.Trace("reset: already cleaned instance", "id", instance.Id())
+	if instance.AlreadyClean {
+		logWasmer.Trace("reset: already cleaned instance", "id", instance.ID())
 		return false
 	}
 
 	result := cWasmerInstanceReset(instance.instance)
 	ok := result == cWasmerOk
 
-	logWasmer.Trace("reset: warm instance", "id", instance.Id(), "ok", ok)
+	logWasmer.Trace("reset: warm instance", "id", instance.ID(), "ok", ok)
 	return ok
 }
 
@@ -366,7 +374,7 @@ func (instance *WasmerInstance) GetVMHooksPtr() uintptr {
 	return *(*uintptr)(instance.vmHooksPtr)
 }
 
-// Id returns an identifier for the instance, unique at runtime
-func (instance *WasmerInstance) Id() string {
+// ID returns an identifier for the instance, unique at runtime
+func (instance *WasmerInstance) ID() string {
 	return fmt.Sprintf("%p", instance.instance)
 }


### PR DESCRIPTION
This PR brings the instance tracker from v1.4 and integrates it in the `RuntimeContext` of VM v1.5.

Extra changes:
* Replace `hasher.Sha256()` with `blake2B`
* Add instance tracker validation at the end of every test