### PR TITLE
Refactor instance calls without lambda functions

### DIFF
--- a/executor/executorInstance.go
+++ b/executor/executorInstance.go
@@ -25,5 +25,5 @@ type Instance interface {
 	SetVMHooksPtr(vmHooksPtr uintptr)
 	GetVMHooksPtr() uintptr
 	ID() string
-	AlreadyCleaned() bool
+	IsAlreadyCleaned() bool
 }

--- a/executor/wrapper/wrapperInstance.go
+++ b/executor/wrapper/wrapperInstance.go
@@ -57,10 +57,10 @@ func (inst *WrapperInstance) Clean() bool {
 	return result
 }
 
-// AlreadyCleaned wraps the call to the underlying instance.
-func (inst *WrapperInstance) AlreadyCleaned() bool {
-	result := inst.wrappedInstance.AlreadyCleaned()
-	inst.logger.LogExecutorEvent(fmt.Sprintf("AlreadyCleaned: %t", result))
+// IsAlreadyCleaned wraps the call to the underlying instance.
+func (inst *WrapperInstance) IsAlreadyCleaned() bool {
+	result := inst.wrappedInstance.IsAlreadyCleaned()
+	inst.logger.LogExecutorEvent(fmt.Sprintf("IsAlreadyCleaned: %t", result))
 	return result
 }
 

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -77,11 +77,6 @@ func (instance *InstanceMock) CallFunction(funcName string) error {
 	return err
 }
 
-// HasMemory mocked method
-func (instance *InstanceMock) HasMemory() bool {
-	return true
-}
-
 // GetPointsUsed mocked method
 func (instance *InstanceMock) GetPointsUsed() uint64 {
 	return instance.Points
@@ -146,6 +141,11 @@ func (instance *InstanceMock) GetFunctionNames() []string {
 // ValidateVoidFunction mocked method
 func (instance *InstanceMock) ValidateVoidFunction(_ string) error {
 	return nil
+}
+
+// HasMemory mocked method
+func (instance *InstanceMock) HasMemory() bool {
+	return true
 }
 
 // MemLoad returns the contents from the given offset of the WASM memory.

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -61,7 +61,7 @@ func (instance *InstanceMock) AddMockMethodWithError(name string, method mockMet
 }
 
 // CallFunction mocked method
-func (instance *InstanceMock) CallFunction(funcName string) (wasmer.Value, error) {
+func (instance *InstanceMock) CallFunction(funcName string) error {
 	err := instance.DefaultErrors[funcName]
 	method := instance.Methods[funcName]
 	newInstance := method()
@@ -74,7 +74,7 @@ func (instance *InstanceMock) CallFunction(funcName string) (wasmer.Value, error
 		}
 		err = errors.New(errMsg)
 	}
-	return wasmer.Void(), err
+	return err
 }
 
 // HasMemory mocked method

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -10,11 +10,15 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/wasmer"
 )
 
+type mockMethod func() *InstanceMock
+
 // InstanceMock is a mock for Wasmer instances; it allows creating mock smart
 // contracts within tests, without needing actual WASM smart contracts.
 type InstanceMock struct {
 	Code            []byte
 	Exports         wasmer.ExportsMap
+	DefaultErrors   map[string]error
+	Methods         map[string]mockMethod
 	Points          uint64
 	Data            executor.VMHooks
 	GasLimit        uint64
@@ -23,6 +27,7 @@ type InstanceMock struct {
 	Host            vmhost.VMHost
 	T               testing.TB
 	Address         []byte
+	AlreadyClean    bool
 }
 
 // NewInstanceMock creates a new InstanceMock
@@ -30,27 +35,54 @@ func NewInstanceMock(code []byte) *InstanceMock {
 	return &InstanceMock{
 		Code:            code,
 		Exports:         make(wasmer.ExportsMap),
+		DefaultErrors:   make(map[string]error),
+		Methods:         make(map[string]mockMethod),
 		Points:          0,
 		Data:            nil,
 		GasLimit:        0,
 		BreakpointValue: 0,
 		Memory:          NewMemoryMock(),
+		AlreadyClean:    false,
 	}
 }
 
-// AddMockMethod adds the provided function as a mocked method to the instance under the specified name.
-func (instance *InstanceMock) AddMockMethod(name string, method func() *InstanceMock) {
-	wrappedMethod := func(...interface{}) (wasmer.Value, error) {
-		instance := method()
-		breakpoint := vmhost.BreakpointValue(instance.GetBreakpointValue())
-		var err error
-		if breakpoint != vmhost.BreakpointNone {
-			err = errors.New(breakpoint.String())
-		}
-		return wasmer.Void(), err
-	}
+// ID -
+func (instance *InstanceMock) ID() string {
+	return fmt.Sprintf("%p", instance)
+}
 
-	instance.Exports[name] = wrappedMethod
+// AddMockMethod adds the provided function as a mocked method to the instance under the specified name.
+func (instance *InstanceMock) AddMockMethod(name string, method mockMethod) {
+	instance.AddMockMethodWithError(name, method, nil)
+}
+
+// AddMockMethodWithError adds the provided function as a mocked method to the instance under the specified name and returns an error
+func (instance *InstanceMock) AddMockMethodWithError(name string, method mockMethod, err error) {
+	instance.Methods[name] = method
+	instance.DefaultErrors[name] = err
+	instance.Exports[name] = &wasmer.ExportedFunctionCallInfo{}
+}
+
+// CallFunction mocked method
+func (instance *InstanceMock) CallFunction(funcName string) (wasmer.Value, error) {
+	err := instance.DefaultErrors[funcName]
+	method := instance.Methods[funcName]
+	newInstance := method()
+	if vmhost.BreakpointValue(instance.GetBreakpointValue()) != vmhost.BreakpointNone {
+		var errMsg string
+		if vmhost.BreakpointValue(instance.GetBreakpointValue()) == vmhost.BreakpointAsyncCall {
+			errMsg = "breakpoint"
+		} else {
+			errMsg = newInstance.Host.Output().GetVMOutput().ReturnMessage
+		}
+		err = errors.New(errMsg)
+	}
+	return wasmer.Void(), err
+}
+
+// HasMemory mocked method
+func (instance *InstanceMock) HasMemory() bool {
+	return true
 }
 
 // GetPointsUsed mocked method
@@ -84,7 +116,14 @@ func (instance *InstanceMock) Cache() ([]byte, error) {
 }
 
 // Clean mocked method
-func (instance *InstanceMock) Clean() {
+func (instance *InstanceMock) Clean() bool {
+	instance.AlreadyClean = true
+	return true
+}
+
+// AlreadyCleaned mocked method
+func (instance *InstanceMock) AlreadyCleaned() bool {
+	return instance.AlreadyClean
 }
 
 // Reset mocked method
@@ -92,20 +131,10 @@ func (instance *InstanceMock) Reset() bool {
 	return true
 }
 
-// CallFunction mocked method
-func (instance *InstanceMock) CallFunction(functionName string) error {
-	if function, ok := instance.Exports[functionName]; ok {
-		_, err := function()
-		return err
-	}
-
-	return executor.ErrFuncNotFound
-}
-
 // HasFunction mocked method
-func (instance *InstanceMock) HasFunction(functionName string) bool {
-	_, ok := instance.Exports[functionName]
-	return ok
+func (instance *InstanceMock) HasFunction(name string) bool {
+	_, has := instance.Methods[name]
+	return has
 }
 
 // GetFunctionNames mocked method
@@ -120,11 +149,6 @@ func (instance *InstanceMock) GetFunctionNames() []string {
 // ValidateVoidFunction mocked method
 func (instance *InstanceMock) ValidateVoidFunction(_ string) error {
 	return nil
-}
-
-// HasMemory mocked method
-func (instance *InstanceMock) HasMemory() bool {
-	return true
 }
 
 // MemLoad returns the contents from the given offset of the WASM memory.

--- a/mock/context/instanceMock.go
+++ b/mock/context/instanceMock.go
@@ -113,8 +113,8 @@ func (instance *InstanceMock) Clean() bool {
 	return true
 }
 
-// AlreadyCleaned mocked method
-func (instance *InstanceMock) AlreadyCleaned() bool {
+// IsAlreadyCleaned mocked method
+func (instance *InstanceMock) IsAlreadyCleaned() bool {
 	return instance.AlreadyClean
 }
 

--- a/vmhost/contexts/async_test.go
+++ b/vmhost/contexts/async_test.go
@@ -63,9 +63,7 @@ func initializeVMAndWasmerAsyncContext() (*contextmock.VMHostMock, *worldmock.Mo
 	world := worldmock.NewMockWorld()
 	host.BlockchainContext, _ = NewBlockchainContext(host, world)
 
-	mockWasmerInstance = &contextmock.InstanceMock{
-		Exports: make(wasmer.ExportsMap),
-	}
+	mockWasmerInstance = contextmock.NewInstanceMock(nil)
 	exec, _ := wasmer.ExecutorFactory().CreateExecutor(executor.ExecutorFactoryArgs{
 		VMHooks:     vmhooks.NewVMHooksImpl(host),
 		OpcodeCosts: gasCostConfig.WASMOpcodeCost,
@@ -335,12 +333,12 @@ func TestAsyncContext_IsValidCallbackName(t *testing.T) {
 	host, _ := initializeVMAndWasmerAsyncContext()
 	async := makeAsyncContext(t, host, nil)
 
-	mockWasmerInstance.Exports["a"] = nil
-	mockWasmerInstance.Exports["my_contract_method_22"] = nil
-	mockWasmerInstance.Exports["not_builtin"] = nil
-	mockWasmerInstance.Exports["callBack"] = nil
-	mockWasmerInstance.Exports["callback"] = nil
-	mockWasmerInstance.Exports["function_do"] = nil
+	mockWasmerInstance.AddMockMethod("a", nil)
+	mockWasmerInstance.AddMockMethod("my_contract_method_22", nil)
+	mockWasmerInstance.AddMockMethod("not_builtin", nil)
+	mockWasmerInstance.AddMockMethod("callBack", nil)
+	mockWasmerInstance.AddMockMethod("callback", nil)
+	mockWasmerInstance.AddMockMethod("function_do", nil)
 
 	require.True(t, async.isValidCallbackName("a"))
 	require.True(t, async.isValidCallbackName("my_contract_method_22"))
@@ -572,8 +570,8 @@ func TestAsyncContext_ExecuteSyncCall_Successful(t *testing.T) {
 	host, _, originalVMInput := initializeVMAndWasmerAsyncContextWithAliceAndBob()
 	host.Runtime().InitStateFromContractCallInput(originalVMInput)
 
-	mockWasmerInstance.Exports["successCallback"] = nil
-	mockWasmerInstance.Exports["errorCallback"] = nil
+	mockWasmerInstance.AddMockMethod("successCallback", nil)
+	mockWasmerInstance.AddMockMethod("errorCallback", nil)
 
 	async := makeAsyncContext(t, host, Alice)
 

--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -357,7 +357,7 @@ func (tracker *instanceTracker) CheckInstances() error {
 	}
 
 	for id, instance := range tracker.instances {
-		if instance.AlreadyCleaned() {
+		if instance.IsAlreadyCleaned() {
 			continue
 		}
 		_, isWarm := warmInstanceCacheByID[id]

--- a/wasmer/error.go
+++ b/wasmer/error.go
@@ -5,16 +5,19 @@ import (
 	"unsafe"
 )
 
-// ErrFailedInstantiation signals that the instantiation failed
+// ErrFailedInstantiation indicates that a Wasmer instance could not be created
 var ErrFailedInstantiation = errors.New("could not create wasmer instance")
 
-// ErrFailedCacheImports signals that the cache imports failed
+// ErrExportNotFound indicates that the requested name was not found among the exports
+var ErrExportNotFound = errors.New("export not found")
+
+// ErrFailedCacheImports indicates that the imports could not be cached
 var ErrFailedCacheImports = errors.New("could not cache imports")
 
-// ErrInvalidBytecode signals that the bytecode is invalid
+// ErrInvalidBytecode indicates that the bytecode is invalid
 var ErrInvalidBytecode = errors.New("invalid bytecode")
 
-// ErrCachingFailed signals that the caching failed
+// ErrCachingFailed indicates that creating the precompilation cache of an instance has failed
 var ErrCachingFailed = errors.New("instance caching failed")
 
 // GetLastError returns the last error message if any, otherwise returns an error.

--- a/wasmer/error.go
+++ b/wasmer/error.go
@@ -8,9 +8,6 @@ import (
 // ErrFailedInstantiation indicates that a Wasmer instance could not be created
 var ErrFailedInstantiation = errors.New("could not create wasmer instance")
 
-// ErrExportNotFound indicates that the requested name was not found among the exports
-var ErrExportNotFound = errors.New("export not found")
-
 // ErrFailedCacheImports indicates that the imports could not be cached
 var ErrFailedCacheImports = errors.New("could not cache imports")
 

--- a/wasmer/wasmerInstance.go
+++ b/wasmer/wasmerInstance.go
@@ -234,8 +234,8 @@ func (instance *WasmerInstance) Clean() bool {
 	return false
 }
 
-// AlreadyCleaned returns the internal field AlreadyClean
-func (instance *WasmerInstance) AlreadyCleaned() bool {
+// IsAlreadyCleaned returns the internal field AlreadyClean
+func (instance *WasmerInstance) IsAlreadyCleaned() bool {
 	return instance.AlreadyClean
 }
 

--- a/wasmer/wasmerInstance.go
+++ b/wasmer/wasmerInstance.go
@@ -56,12 +56,19 @@ func (error *ExportedFunctionError) Error() string {
 	return error.message
 }
 
-// types used in the wasmer instances management process
-type (
-	ExportedFunctionCallback func(...interface{}) (Value, error)
-	ExportsMap               map[string]ExportedFunctionCallback
-	ExportSignaturesMap      map[string]*ExportedFunctionSignature
-)
+// ExportsMap is a map of names to ExportedFunctionCallInfo values
+type ExportsMap map[string]*ExportedFunctionCallInfo
+
+// ExportSignaturesMap is a map of names to ExportedFunctionSignatures
+type ExportSignaturesMap map[string]*ExportedFunctionSignature
+
+// ExportedFunctionCallInfo contains information required to call an exported WASM function
+type ExportedFunctionCallInfo struct {
+	FuncName       string
+	InputArity     cUint32T
+	InputSignature []cWasmerValueTag
+	OutputArity    cUint32T
+}
 
 // WasmerInstance represents a WebAssembly instance.
 type WasmerInstance struct {
@@ -138,6 +145,8 @@ func NewInstanceWithOptions(
 		cInstanceContext := cWasmerInstanceContextGet(cInstance)
 		instance.InstanceCtx = IntoInstanceContextDirect(cInstanceContext)
 	}
+
+	logWasmer.Trace("new instance created", "id", instance.ID())
 	return instance, err
 }
 
@@ -284,12 +293,12 @@ func (instance *WasmerInstance) IsFunctionImported(name string) bool {
 
 // CallFunction executes given function from loaded contract.
 func (instance *WasmerInstance) CallFunction(functionName string) error {
-	if function, ok := instance.exports[functionName]; ok {
-		_, err := function()
-		return err
+	callInfo, found := instance.exports[functionName]
+	if !found {
+		return executor.ErrFuncNotFound
 	}
 
-	return executor.ErrFuncNotFound
+	return callExportedFunction(instance.instance, callInfo)
 }
 
 // HasFunction checks if loaded contract has a function (endpoint) with given name.


### PR DESCRIPTION
This PR reorganizes the code which called WASM methods from an instance.

Previously, a lambda function was defined and stored, causing potential memory leaks in conjunction with warm instances.

The new code removes the need for the lambdas, using only regular functions instead.