### PR TITLE
Minor refactor of the test framework

### DIFF
--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -45,8 +45,8 @@ func (mockSC *InstanceTestSmartContract) WithCode(code []byte) *InstanceTestSmar
 	return mockSC
 }
 
-// InstancesTestTemplate holds the data to build a contract call test
-type InstancesTestTemplate struct {
+// InstanceCallTestTemplate holds the data to build a contract call test
+type InstanceCallTestTemplate struct {
 	testTemplateConfig
 	contracts     []*InstanceTestSmartContract
 	setup         func(vmhost.VMHost, *contextmock.BlockchainHookStub)
@@ -56,8 +56,8 @@ type InstancesTestTemplate struct {
 }
 
 // BuildInstanceCallTest starts the building process for a contract call test
-func BuildInstanceCallTest(tb testing.TB) *InstancesTestTemplate {
-	return &InstancesTestTemplate{
+func BuildInstanceCallTest(tb testing.TB) *InstanceCallTestTemplate {
+	return &InstanceCallTestTemplate{
 		testTemplateConfig: testTemplateConfig{
 			tb:                       tb,
 			useMocks:                 false,
@@ -69,88 +69,88 @@ func BuildInstanceCallTest(tb testing.TB) *InstancesTestTemplate {
 }
 
 // WithContracts provides the contracts to be used by the contract call test
-func (callerTest *InstancesTestTemplate) WithContracts(usedContracts ...*InstanceTestSmartContract) *InstancesTestTemplate {
-	callerTest.contracts = usedContracts
-	return callerTest
+func (template *InstanceCallTestTemplate) WithContracts(usedContracts ...*InstanceTestSmartContract) *InstanceCallTestTemplate {
+	template.contracts = usedContracts
+	return template
 }
 
 // WithInput provides the ContractCallInput to be used by the contract call test
-func (callerTest *InstancesTestTemplate) WithInput(input *vmcommon.ContractCallInput) *InstancesTestTemplate {
-	callerTest.input = input
-	return callerTest
+func (template *InstanceCallTestTemplate) WithInput(input *vmcommon.ContractCallInput) *InstanceCallTestTemplate {
+	template.input = input
+	return template
 }
 
 // WithSetup provides the setup function to be used by the contract call test
-func (callerTest *InstancesTestTemplate) WithSetup(setup func(vmhost.VMHost, *contextmock.BlockchainHookStub)) *InstancesTestTemplate {
-	callerTest.setup = setup
-	return callerTest
+func (template *InstanceCallTestTemplate) WithSetup(setup func(vmhost.VMHost, *contextmock.BlockchainHookStub)) *InstanceCallTestTemplate {
+	template.setup = setup
+	return template
 }
 
 // WithGasSchedule provides gas schedule for the test
-func (callerTest *InstancesTestTemplate) WithGasSchedule(gasSchedule config.GasScheduleMap) *InstancesTestTemplate {
-	callerTest.hostBuilder.WithGasSchedule(gasSchedule)
-	return callerTest
+func (template *InstanceCallTestTemplate) WithGasSchedule(gasSchedule config.GasScheduleMap) *InstanceCallTestTemplate {
+	template.hostBuilder.WithGasSchedule(gasSchedule)
+	return template
 }
 
 // WithExecutorFactory provides the wasmer executor for the test
-func (callerTest *InstancesTestTemplate) WithExecutorFactory(executorFactory executor.ExecutorAbstractFactory) *InstancesTestTemplate {
-	callerTest.hostBuilder.WithExecutorFactory(executorFactory)
-	return callerTest
+func (template *InstanceCallTestTemplate) WithExecutorFactory(executorFactory executor.ExecutorAbstractFactory) *InstanceCallTestTemplate {
+	template.hostBuilder.WithExecutorFactory(executorFactory)
+	return template
 }
 
 // WithExecutorLogs sets an ExecutorLogger
-func (callerTest *InstancesTestTemplate) WithExecutorLogs(executorLogger executorwrapper.ExecutorLogger) *InstancesTestTemplate {
-	callerTest.hostBuilder.WithExecutorLogs(executorLogger)
-	return callerTest
+func (template *InstanceCallTestTemplate) WithExecutorLogs(executorLogger executorwrapper.ExecutorLogger) *InstanceCallTestTemplate {
+	template.hostBuilder.WithExecutorLogs(executorLogger)
+	return template
 }
 
 // WithWasmerSIGSEGVPassthrough sets the wasmerSIGSEGVPassthrough flag
-func (callerTest *InstancesTestTemplate) WithWasmerSIGSEGVPassthrough(passthrough bool) *InstancesTestTemplate {
-	callerTest.hostBuilder.WithWasmerSIGSEGVPassthrough(passthrough)
-	return callerTest
+func (template *InstanceCallTestTemplate) WithWasmerSIGSEGVPassthrough(passthrough bool) *InstanceCallTestTemplate {
+	template.hostBuilder.WithWasmerSIGSEGVPassthrough(passthrough)
+	return template
 }
 
 // GetVMHost returns the inner VMHost
-func (callerTest *InstancesTestTemplate) GetVMHost() vmhost.VMHost {
-	return callerTest.host
+func (template *InstanceCallTestTemplate) GetVMHost() vmhost.VMHost {
+	return template.host
 }
 
 // AndAssertResults starts the test and asserts the results
-func (callerTest *InstancesTestTemplate) AndAssertResults(assertResults func(vmhost.VMHost, *contextmock.BlockchainHookStub, *VMOutputVerifier)) {
-	callerTest.assertResults = assertResults
-	runTestWithInstances(callerTest, true)
+func (template *InstanceCallTestTemplate) AndAssertResults(assertResults func(vmhost.VMHost, *contextmock.BlockchainHookStub, *VMOutputVerifier)) {
+	template.assertResults = assertResults
+	runTestWithInstances(template, true)
 }
 
 // AndAssertResultsWithoutReset starts the test and asserts the results
-func (callerTest *InstancesTestTemplate) AndAssertResultsWithoutReset(assertResults func(vmhost.VMHost, *contextmock.BlockchainHookStub, *VMOutputVerifier)) {
-	callerTest.assertResults = assertResults
-	runTestWithInstances(callerTest, false)
+func (template *InstanceCallTestTemplate) AndAssertResultsWithoutReset(assertResults func(vmhost.VMHost, *contextmock.BlockchainHookStub, *VMOutputVerifier)) {
+	template.assertResults = assertResults
+	runTestWithInstances(template, false)
 }
 
-func runTestWithInstances(callerTest *InstancesTestTemplate, reset bool) {
+func runTestWithInstances(template *InstanceCallTestTemplate, reset bool) {
 	var blhookStub *contextmock.BlockchainHookStub
-	if callerTest.host == nil {
-		blhookStub = BlockchainHookStubForContracts(callerTest.contracts)
-		callerTest.hostBuilder.WithBlockchainHook(blhookStub)
-		callerTest.host = callerTest.hostBuilder.Build()
-		callerTest.setup(callerTest.host, blhookStub)
+	if template.host == nil {
+		blhookStub = BlockchainHookStubForContracts(template.contracts)
+		template.hostBuilder.WithBlockchainHook(blhookStub)
+		template.host = template.hostBuilder.Build()
+		template.setup(template.host, blhookStub)
 	}
 
 	defer func() {
 		if reset {
-			callerTest.host.Reset()
+			template.host.Reset()
 		}
 
 		// Extra verification for instance leaks
-		err := callerTest.host.Runtime().ValidateInstances()
-		require.Nil(callerTest.tb, err)
+		err := template.host.Runtime().ValidateInstances()
+		require.Nil(template.tb, err)
 	}()
 
-	vmOutput, err := callerTest.host.RunSmartContractCall(callerTest.input)
+	vmOutput, err := template.host.RunSmartContractCall(template.input)
 
-	if callerTest.assertResults != nil {
-		allErrors := callerTest.host.Runtime().GetAllErrors()
-		verify := NewVMOutputVerifierWithAllErrors(callerTest.tb, vmOutput, err, allErrors)
-		callerTest.assertResults(callerTest.host, blhookStub, verify)
+	if template.assertResults != nil {
+		allErrors := template.host.Runtime().GetAllErrors()
+		verify := NewVMOutputVerifierWithAllErrors(template.tb, vmOutput, err, allErrors)
+		template.assertResults(template.host, blhookStub, verify)
 	}
 }

--- a/testcommon/instanceSmartContractCreatorTest.go
+++ b/testcommon/instanceSmartContractCreatorTest.go
@@ -14,7 +14,7 @@ import (
 
 // InstanceCreatorTestTemplate holds the data to build a contract creation test
 type InstanceCreatorTestTemplate struct {
-	t                       *testing.T
+	tb                      testing.TB
 	address                 []byte
 	input                   *vmcommon.ContractCreateInput
 	setup                   func(vmhost.VMHost, *contextmock.BlockchainHookStub)
@@ -26,11 +26,11 @@ type InstanceCreatorTestTemplate struct {
 }
 
 // BuildInstanceCreatorTest starts the building process for a contract creation test
-func BuildInstanceCreatorTest(t *testing.T) *InstanceCreatorTestTemplate {
+func BuildInstanceCreatorTest(tb testing.TB) *InstanceCreatorTestTemplate {
 	return &InstanceCreatorTestTemplate{
-		t:                       t,
+		tb:                      tb,
 		setup:                   func(vmhost.VMHost, *contextmock.BlockchainHookStub) {},
-		hostBuilder:             NewTestHostBuilder(t),
+		hostBuilder:             NewTestHostBuilder(tb),
 		stubAccountInitialNonce: 24,
 	}
 }
@@ -98,12 +98,12 @@ func (template *InstanceCreatorTestTemplate) runTest(reset bool) {
 
 		// Extra verification for instance leaks
 		err := template.host.Runtime().ValidateInstances()
-		require.Nil(template.t, err)
+		require.Nil(template.tb, err)
 	}()
 
 	vmOutput, err := template.host.RunSmartContractCreate(template.input)
 
-	verify := NewVMOutputVerifier(template.t, vmOutput, err)
+	verify := NewVMOutputVerifier(template.tb, vmOutput, err)
 	template.assertResults(blhookStub, verify)
 }
 

--- a/testcommon/instanceSmartContractCreatorTest.go
+++ b/testcommon/instanceSmartContractCreatorTest.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-go/config"
 	"github.com/multiversx/mx-chain-vm-go/executor"
 	executorwrapper "github.com/multiversx/mx-chain-vm-go/executor/wrapper"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
@@ -21,7 +20,6 @@ type InstanceCreatorTestTemplate struct {
 	assertResults           func(*contextmock.BlockchainHookStub, *VMOutputVerifier)
 	host                    vmhost.VMHost
 	hostBuilder             *TestHostBuilder
-	gasSchedule             config.GasScheduleMap
 	stubAccountInitialNonce uint64
 }
 

--- a/testcommon/testHostBuilder.go
+++ b/testcommon/testHostBuilder.go
@@ -1,0 +1,136 @@
+package testcommon
+
+import (
+	"testing"
+
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
+	"github.com/multiversx/mx-chain-vm-common-go/parsers"
+	"github.com/multiversx/mx-chain-vm-go/config"
+	"github.com/multiversx/mx-chain-vm-go/executor"
+	executorwrapper "github.com/multiversx/mx-chain-vm-go/executor/wrapper"
+	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
+	"github.com/multiversx/mx-chain-vm-go/testcommon/testexecutor"
+	"github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/multiversx/mx-chain-vm-go/vmhost/hostCore"
+	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
+	"github.com/stretchr/testify/require"
+)
+
+// TestHostBuilder allows tests to configure and initialize the VM host and blockhain mock on which they operate.
+type TestHostBuilder struct {
+	tb               testing.TB
+	blockchainHook   vmcommon.BlockchainHook
+	vmHostParameters *vmhost.VMHostParameters
+	host             vmhost.VMHost
+}
+
+// NewTestHostBuilder commences a test host builder pattern.
+func NewTestHostBuilder(tb testing.TB) *TestHostBuilder {
+	esdtTransferParser, _ := parsers.NewESDTTransferParser(worldmock.WorldMarshalizer)
+	return &TestHostBuilder{
+		tb: tb,
+		vmHostParameters: &vmhost.VMHostParameters{
+			VMType:                   DefaultVMType,
+			BlockGasLimit:            uint64(1000),
+			GasSchedule:              nil,
+			BuiltInFuncContainer:     nil,
+			ProtectedKeyPrefix:       []byte("E" + "L" + "R" + "O" + "N" + "D"),
+			ESDTTransferParser:       esdtTransferParser,
+			EpochNotifier:            &mock.EpochNotifierStub{},
+			EnableEpochsHandler:      worldmock.EnableEpochsHandlerStubAllFlags(),
+			OverrideVMExecutor:       testexecutor.NewDefaultTestExecutorFactory(tb),
+			WasmerSIGSEGVPassthrough: false,
+			Hasher:                   defaultHasher,
+		},
+	}
+}
+
+// Ensures gas costs are initialized.
+func (thb *TestHostBuilder) initializeGasCosts() {
+	if thb.vmHostParameters.GasSchedule == nil {
+		thb.vmHostParameters.GasSchedule = config.MakeGasMapForTests()
+	}
+}
+
+// Ensures the built-in function container is initialized.
+func (thb *TestHostBuilder) initializeBuiltInFuncContainer() {
+	if thb.vmHostParameters.BuiltInFuncContainer == nil {
+		thb.vmHostParameters.BuiltInFuncContainer = builtInFunctions.NewBuiltInFunctionContainer()
+	}
+
+}
+
+// WithBlockchainHook sets a pre-built blockchain hook for the VM to work with.
+func (thb *TestHostBuilder) WithBlockchainHook(blockchainHook vmcommon.BlockchainHook) *TestHostBuilder {
+	thb.blockchainHook = blockchainHook
+	return thb
+}
+
+// WithBuiltinFunctions sets up builtin functions in the blockchain hook.
+// Only works if the blockchain hook is of type worldmock.MockWorld.
+func (thb *TestHostBuilder) WithBuiltinFunctions() *TestHostBuilder {
+	thb.initializeGasCosts()
+	mockWorld, ok := thb.blockchainHook.(*worldmock.MockWorld)
+	require.True(thb.tb, ok, "builtin functions can only be injected into blockchain hooks of type MockWorld")
+	err := mockWorld.InitBuiltinFunctions(thb.vmHostParameters.GasSchedule)
+	require.Nil(thb.tb, err)
+	thb.vmHostParameters.BuiltInFuncContainer = mockWorld.BuiltinFuncs.Container
+	return thb
+}
+
+// WithExecutorFactory allows tests to choose what executor to use.
+func (thb *TestHostBuilder) WithExecutorFactory(executorFactory executor.ExecutorAbstractFactory) *TestHostBuilder {
+	thb.vmHostParameters.OverrideVMExecutor = executorFactory
+	return thb
+}
+
+// WithExecutorLogs sets an ExecutorLogger, which wraps the existing OverrideVMExecutor
+func (thb *TestHostBuilder) WithExecutorLogs(executorLogger executorwrapper.ExecutorLogger) *TestHostBuilder {
+	if thb.vmHostParameters.OverrideVMExecutor == nil {
+		thb.tb.Fatal("WithExecutorLogs() requires WithExecutorFactory()")
+	}
+
+	wrapper := executorwrapper.NewWrappedExecutorFactory(
+		executorLogger,
+		thb.vmHostParameters.OverrideVMExecutor)
+
+	return thb.WithExecutorFactory(wrapper)
+}
+
+// WithWasmerSIGSEGVPassthrough allows tests to configure the WasmerSIGSEGVPassthrough flag.
+func (thb *TestHostBuilder) WithWasmerSIGSEGVPassthrough(wasmerSIGSEGVPassthrough bool) *TestHostBuilder {
+	thb.vmHostParameters.WasmerSIGSEGVPassthrough = wasmerSIGSEGVPassthrough
+	return thb
+}
+
+// WithGasSchedule allows tests to use the gas costs. The default is config.MakeGasMapForTests().
+func (thb *TestHostBuilder) WithGasSchedule(gasSchedule config.GasScheduleMap) *TestHostBuilder {
+	thb.vmHostParameters.GasSchedule = gasSchedule
+	return thb
+}
+
+// Build initializes the VM host with all configured options.
+func (thb *TestHostBuilder) Build() vmhost.VMHost {
+	thb.initializeHost()
+	return thb.host
+}
+
+func (thb *TestHostBuilder) initializeHost() {
+	thb.initializeGasCosts()
+	if thb.host == nil {
+		thb.host = thb.newHost()
+	}
+}
+
+func (thb *TestHostBuilder) newHost() vmhost.VMHost {
+	thb.initializeBuiltInFuncContainer()
+	host, err := hostCore.NewVMHost(
+		thb.blockchainHook,
+		thb.vmHostParameters,
+	)
+	require.Nil(thb.tb, err)
+	require.NotNil(thb.tb, host)
+
+	return host
+}

--- a/testcommon/testHostBuilder.go
+++ b/testcommon/testHostBuilder.go
@@ -10,7 +10,6 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/executor"
 	executorwrapper "github.com/multiversx/mx-chain-vm-go/executor/wrapper"
 	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
-	"github.com/multiversx/mx-chain-vm-go/testcommon/testexecutor"
 	"github.com/multiversx/mx-chain-vm-go/vmhost"
 	"github.com/multiversx/mx-chain-vm-go/vmhost/hostCore"
 	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
@@ -39,7 +38,7 @@ func NewTestHostBuilder(tb testing.TB) *TestHostBuilder {
 			ESDTTransferParser:       esdtTransferParser,
 			EpochNotifier:            &mock.EpochNotifierStub{},
 			EnableEpochsHandler:      worldmock.EnableEpochsHandlerStubAllFlags(),
-			OverrideVMExecutor:       testexecutor.NewDefaultTestExecutorFactory(tb),
+			OverrideVMExecutor:       nil,
 			WasmerSIGSEGVPassthrough: false,
 			Hasher:                   defaultHasher,
 		},

--- a/testcommon/testInitializerInputs.go
+++ b/testcommon/testInitializerInputs.go
@@ -8,23 +8,13 @@ import (
 	"math/big"
 	"path/filepath"
 	"strings"
-	"testing"
 
 	"github.com/multiversx/mx-chain-core-go/core"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	"github.com/multiversx/mx-chain-core-go/hashing/blake2b"
 	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
-	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
-	"github.com/multiversx/mx-chain-vm-common-go/parsers"
-	"github.com/multiversx/mx-chain-vm-go/config"
-	"github.com/multiversx/mx-chain-vm-go/executor"
-	executorwrapper "github.com/multiversx/mx-chain-vm-go/executor/wrapper"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
 	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
-	"github.com/multiversx/mx-chain-vm-go/vmhost"
-	"github.com/multiversx/mx-chain-vm-go/vmhost/hostCore"
-	"github.com/multiversx/mx-chain-vm-go/vmhost/mock"
-	"github.com/stretchr/testify/require"
 )
 
 var defaultHasher = blake2b.NewBlake2b()
@@ -117,123 +107,6 @@ func GetTestSCCode(scName string, prefixToTestSCs ...string) []byte {
 func GetTestSCCodeModule(scName string, moduleName string, prefixToTestSCs string) []byte {
 	pathToSC := prefixToTestSCs + "test/contracts/" + scName + "/output/" + moduleName + ".wasm"
 	return GetSCCode(pathToSC)
-}
-
-// TestHostBuilder allows tests to configure and initialize the VM host and blockhain mock on which they operate.
-type TestHostBuilder struct {
-	tb               testing.TB
-	blockchainHook   vmcommon.BlockchainHook
-	vmHostParameters *vmhost.VMHostParameters
-	host             vmhost.VMHost
-}
-
-// NewTestHostBuilder commences a test host builder pattern.
-func NewTestHostBuilder(tb testing.TB) *TestHostBuilder {
-	esdtTransferParser, _ := parsers.NewESDTTransferParser(worldmock.WorldMarshalizer)
-	return &TestHostBuilder{
-		tb: tb,
-		vmHostParameters: &vmhost.VMHostParameters{
-			VMType:                   DefaultVMType,
-			BlockGasLimit:            uint64(1000),
-			GasSchedule:              nil,
-			BuiltInFuncContainer:     nil,
-			ProtectedKeyPrefix:       []byte("E" + "L" + "R" + "O" + "N" + "D"),
-			ESDTTransferParser:       esdtTransferParser,
-			EpochNotifier:            &mock.EpochNotifierStub{},
-			EnableEpochsHandler:      worldmock.EnableEpochsHandlerStubAllFlags(),
-			WasmerSIGSEGVPassthrough: false,
-			Hasher:                   defaultHasher,
-		},
-	}
-}
-
-// Ensures gas costs are initialized.
-func (thb *TestHostBuilder) initializeGasCosts() {
-	if thb.vmHostParameters.GasSchedule == nil {
-		thb.vmHostParameters.GasSchedule = config.MakeGasMapForTests()
-	}
-}
-
-// Ensures the built-in function container is initialized.
-func (thb *TestHostBuilder) initializeBuiltInFuncContainer() {
-	if thb.vmHostParameters.BuiltInFuncContainer == nil {
-		thb.vmHostParameters.BuiltInFuncContainer = builtInFunctions.NewBuiltInFunctionContainer()
-	}
-
-}
-
-// WithBlockchainHook sets a pre-built blockchain hook for the VM to work with.
-func (thb *TestHostBuilder) WithBlockchainHook(blockchainHook vmcommon.BlockchainHook) *TestHostBuilder {
-	thb.blockchainHook = blockchainHook
-	return thb
-}
-
-// WithBuiltinFunctions sets up builtin functions in the blockchain hook.
-// Only works if the blockchain hook is of type worldmock.MockWorld.
-func (thb *TestHostBuilder) WithBuiltinFunctions() *TestHostBuilder {
-	thb.initializeGasCosts()
-	mockWorld, ok := thb.blockchainHook.(*worldmock.MockWorld)
-	require.True(thb.tb, ok, "builtin functions can only be injected into blockchain hooks of type MockWorld")
-	err := mockWorld.InitBuiltinFunctions(thb.vmHostParameters.GasSchedule)
-	require.Nil(thb.tb, err)
-	thb.vmHostParameters.BuiltInFuncContainer = mockWorld.BuiltinFuncs.Container
-	return thb
-}
-
-// WithExecutorFactory allows tests to choose what executor to use.
-func (thb *TestHostBuilder) WithExecutorFactory(executorFactory executor.ExecutorAbstractFactory) *TestHostBuilder {
-	thb.vmHostParameters.OverrideVMExecutor = executorFactory
-	return thb
-}
-
-// WithExecutorLogs sets an ExecutorLogger, which wraps the existing OverrideVMExecutor
-func (thb *TestHostBuilder) WithExecutorLogs(executorLogger executorwrapper.ExecutorLogger) *TestHostBuilder {
-	if thb.vmHostParameters.OverrideVMExecutor == nil {
-		thb.tb.Fatal("WithExecutorLogs() requires WithExecutorFactory()")
-	}
-
-	wrapper := executorwrapper.NewWrappedExecutorFactory(
-		executorLogger,
-		thb.vmHostParameters.OverrideVMExecutor)
-
-	return thb.WithExecutorFactory(wrapper)
-}
-
-// WithWasmerSIGSEGVPassthrough allows tests to configure the WasmerSIGSEGVPassthrough flag.
-func (thb *TestHostBuilder) WithWasmerSIGSEGVPassthrough(wasmerSIGSEGVPassthrough bool) *TestHostBuilder {
-	thb.vmHostParameters.WasmerSIGSEGVPassthrough = wasmerSIGSEGVPassthrough
-	return thb
-}
-
-// WithGasSchedule allows tests to use the gas costs. The default is config.MakeGasMapForTests().
-func (thb *TestHostBuilder) WithGasSchedule(gasSchedule config.GasScheduleMap) *TestHostBuilder {
-	thb.vmHostParameters.GasSchedule = gasSchedule
-	return thb
-}
-
-// Build initializes the VM host with all configured options.
-func (thb *TestHostBuilder) Build() vmhost.VMHost {
-	thb.initializeHost()
-	return thb.host
-}
-
-func (thb *TestHostBuilder) initializeHost() {
-	thb.initializeGasCosts()
-	if thb.host == nil {
-		thb.host = thb.newHost()
-	}
-}
-
-func (thb *TestHostBuilder) newHost() vmhost.VMHost {
-	thb.initializeBuiltInFuncContainer()
-	host, err := hostCore.NewVMHost(
-		thb.blockchainHook,
-		thb.vmHostParameters,
-	)
-	require.Nil(thb.tb, err)
-	require.NotNil(thb.tb, host)
-
-	return host
 }
 
 // BlockchainHookStubForCallSigSegv -

--- a/vmhost/contexts/storage_test.go
+++ b/vmhost/contexts/storage_test.go
@@ -484,8 +484,6 @@ func TestStorageContext_GetStorageFromAddress(t *testing.T) {
 	}
 
 	t.Run("blockchain hook errors", func(t *testing.T) {
-		t.Parallel()
-
 		errTooManyRequests := errors.New("too many requests")
 		bcHook := makeBcHookStub(
 			scAddress,
@@ -511,8 +509,6 @@ func TestStorageContext_GetStorageFromAddress(t *testing.T) {
 		require.Equal(t, errTooManyRequests, err)
 	})
 	t.Run("should work when blockchain hook does not error", func(t *testing.T) {
-		t.Parallel()
-
 		internalData := []byte("internalData")
 
 		bcHook := makeBcHookStub(

--- a/vmhost/hostCore/host.go
+++ b/vmhost/hostCore/host.go
@@ -30,7 +30,7 @@ var MaximumRuntimeInstanceStackSize = uint64(10)
 
 var _ vmhost.VMHost = (*vmHost)(nil)
 
-const minExecutionTimeout = time.Minute
+const minExecutionTimeout = time.Second
 const internalVMErrors = "internalVMErrors"
 
 var defaultVMExecutorFactory executor.ExecutorAbstractFactory = wasmer2.ExecutorFactory()

--- a/vmhost/hosttest/bad_test.go
+++ b/vmhost/hosttest/bad_test.go
@@ -215,7 +215,6 @@ func TestBadContract_NoPanic_BadGetBlockHash3(t *testing.T) {
 }
 
 func TestBadContract_NoPanic_BadRecursive(t *testing.T) {
-	t.Skip()
 	test.BuildInstanceCallTest(t).
 		WithContracts(
 			test.CreateInstanceContract(test.ParentAddress).

--- a/vmhost/hosttest/execution_builtin_test.go
+++ b/vmhost/hosttest/execution_builtin_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/multiversx/mx-chain-vm-common-go/builtInFunctions"
 	"github.com/multiversx/mx-chain-vm-go/config"
 	"github.com/multiversx/mx-chain-vm-go/executor"
-	executorwrapper "github.com/multiversx/mx-chain-vm-go/executor/wrapper"
 	contextmock "github.com/multiversx/mx-chain-vm-go/mock/context"
 	worldmock "github.com/multiversx/mx-chain-vm-go/mock/world"
 	test "github.com/multiversx/mx-chain-vm-go/testcommon"
@@ -128,7 +127,6 @@ func TestExecution_ExecuteOnDestContext_MockBuiltinFunctions_Nonexistent(t *test
 			WithGasProvided(test.GasProvided).
 			WithFunction("callNonexistingBuiltin").
 			Build()).
-		WithExecutorLogs(executorwrapper.NewConsoleLogger()).
 		WithExecutorFactory(wasmer2.ExecutorFactory()).
 		WithSetup(func(host vmhost.VMHost, stubBlockchainHook *contextmock.BlockchainHookStub) {
 			stubBlockchainHook.ProcessBuiltInFunctionCalled = dummyProcessBuiltInFunction

--- a/vmhost/hosttest/execution_test.go
+++ b/vmhost/hosttest/execution_test.go
@@ -148,7 +148,7 @@ func TestExecution_DeployWASM_WrongInit_Wasmer2(t *testing.T) {
 
 func testExecution_DeployWASM_WrongInit(t *testing.T, executorFactory executor.ExecutorAbstractFactory) {
 	test.BuildInstanceCreatorTest(t).
-		WithExecutor(executorFactory).
+		WithExecutorFactory(executorFactory).
 		WithInput(test.CreateTestContractCreateInputBuilder().
 			WithGasProvided(1000).
 			WithContractCode(test.GetTestSCCode("init-wrong", "../../")).
@@ -324,7 +324,6 @@ func TestExecution_MultipleInstances_SameVMHooks(t *testing.T) {
 	}
 	require.False(t, len(vmHooksPtr) > 1)
 }
-
 
 func TestExecution_MultipleVMs_OverlappingDifferentVMHooks(t *testing.T) {
 	t.Skip()

--- a/vmhost/hosttest/panictests/panic_test.go
+++ b/vmhost/hosttest/panictests/panic_test.go
@@ -15,7 +15,6 @@ import (
 const increment = "increment"
 
 func TestExecution_PanicInGoWithSilentWasmer_SIGSEGV(t *testing.T) {
-	t.Skip()
 	code := test.GetTestSCCode("counter", "../../../")
 	blockchain := test.BlockchainHookStubForCallSigSegv(code, big.NewInt(1))
 	host := test.NewTestHostBuilder(t).
@@ -50,7 +49,6 @@ func TestExecution_PanicInGoWithSilentWasmer_SIGSEGV(t *testing.T) {
 }
 
 func TestExecution_PanicInGoWithSilentWasmer_SIGFPE(t *testing.T) {
-	t.Skip()
 	code := test.GetTestSCCode("counter", "../../../")
 	blockchain := test.BlockchainHookStubForCallSigSegv(code, big.NewInt(1))
 	host := test.NewTestHostBuilder(t).
@@ -88,7 +86,6 @@ func TestExecution_PanicInGoWithSilentWasmer_SIGFPE(t *testing.T) {
 }
 
 func TestExecution_PanicInGoWithSilentWasmer_Timeout(t *testing.T) {
-	t.Skip()
 	code := test.GetTestSCCode("counter", "../../../")
 	blockchain := test.BlockchainHookStubForCallSigSegv(code, big.NewInt(1))
 	host := test.NewTestHostBuilder(t).
@@ -120,7 +117,6 @@ func TestExecution_PanicInGoWithSilentWasmer_Timeout(t *testing.T) {
 }
 
 func TestExecution_PanicInGoWithSilentWasmer_TimeoutAndSIGSEGV(t *testing.T) {
-	t.Skip()
 	code := test.GetTestSCCode("counter", "../../../")
 	blockchain := test.BlockchainHookStubForCallSigSegv(code, big.NewInt(1))
 	host := test.NewTestHostBuilder(t).
@@ -157,7 +153,6 @@ func TestExecution_PanicInGoWithSilentWasmer_TimeoutAndSIGSEGV(t *testing.T) {
 }
 
 func TestExecution_MultipleHostsPanicInGoWithSilentWasmer_TimeoutAndSIGSEGV(t *testing.T) {
-	t.Skip()
 	numParallel := 100
 	hosts := make([]vmhost.VMHost, numParallel)
 	blockchains := make([]*mock.BlockchainHookStub, numParallel)


### PR DESCRIPTION
This PR brings the following changes:
* `InstancesTestTemplate` → `InstanceCallTestTemplate`
* `TestCreateTemplateConfig` → `InstanceCreatorTestTemplate`
* Integrate the `TestHostBuilder` into both `InstanceCallTestTemplate` and `InstanceCreatorTestTemplate`, thereby simplifying them
* Move `TestHostBuilder` into its own file under `testcommon`

These changes are done in preparation for a global executor switch in tests.