### PR TITLE
Fix Runtime.codeSize for v1.5

### DIFF
--- a/testcommon/instanceSmartContractCallerTest.go
+++ b/testcommon/instanceSmartContractCallerTest.go
@@ -20,7 +20,8 @@ type InstanceTestSmartContract struct {
 func CreateInstanceContract(address []byte) *InstanceTestSmartContract {
 	return &InstanceTestSmartContract{
 		testSmartContract: testSmartContract{
-			address: address,
+			address:      address,
+			ownerAddress: UserAddress,
 		},
 	}
 }
@@ -40,6 +41,18 @@ func (mockSC *InstanceTestSmartContract) WithConfig(testConfig *TestConfig) *Ins
 // WithCode provides the code for the InstanceTestSmartContract
 func (mockSC *InstanceTestSmartContract) WithCode(code []byte) *InstanceTestSmartContract {
 	mockSC.code = code
+	return mockSC
+}
+
+// WithOwner provides the owner for the InstanceTestSmartContract
+func (mockSC *InstanceTestSmartContract) WithOwner(owner []byte) *InstanceTestSmartContract {
+	mockSC.ownerAddress = owner
+	return mockSC
+}
+
+// WithCodeMetadata provides the owner for the InstanceTestSmartContract
+func (mockSC *InstanceTestSmartContract) WithCodeMetadata(metadata []byte) *InstanceTestSmartContract {
+	mockSC.codeMetadata = metadata
 	return mockSC
 }
 

--- a/testcommon/testInitializerInputs.go
+++ b/testcommon/testInitializerInputs.go
@@ -76,12 +76,12 @@ func MakeTestSCAddress(identifier string) []byte {
 // MakeTestSCAddressWithDefaultVM generates a new smart contract address to be used for
 // testing based on the given identifier.
 func MakeTestSCAddressWithDefaultVM(identifier string) []byte {
-	return MakeTestSCAddressWithVmType(identifier, worldmock.DefaultVMType)
+	return MakeTestSCAddressWithVMType(identifier, worldmock.DefaultVMType)
 }
 
-// MakeTestSCAddressWithVmType generates a new smart contract address to be used for
+// MakeTestSCAddressWithVMType generates a new smart contract address to be used for
 // testing based on the given identifier.
-func MakeTestSCAddressWithVmType(identifier string, vmType []byte) []byte {
+func MakeTestSCAddressWithVMType(identifier string, vmType []byte) []byte {
 	address := MakeTestSCAddress(identifier)
 	copy(address[vmcommon.NumInitCharactersForScAddress-core.VMTypeLen:], vmType)
 	return address
@@ -320,7 +320,7 @@ func BlockchainHookStubForContracts(
 			Balance:      big.NewInt(contract.balance),
 			CodeHash:     codeHash,
 			CodeMetadata: DefaultCodeMetadata,
-			OwnerAddress: ParentAddress,
+			OwnerAddress: contract.ownerAddress,
 		}
 		codeMap[string(contract.address)] = &contract.code
 	}

--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -326,7 +326,6 @@ func (tracker *instanceTracker) UnsetInstance() {
 		"codeHash", tracker.codeHash)
 	tracker.instance = nil
 	tracker.codeHash = nil
-	tracker.codeSize = 0
 }
 
 // LogCounts prints the instance counter to the log

--- a/vmhost/contexts/instanceTracker.go
+++ b/vmhost/contexts/instanceTracker.go
@@ -32,12 +32,14 @@ var logTracker = logger.GetOrCreate("vm/tracker")
 
 type instanceTracker struct {
 	codeHash            []byte
+	codeSize            uint64
 	numRunningInstances int
 	warmInstanceCache   Cacher
 	instance            executor.Instance
 	cacheLevel          instanceCacheLevel
 	instanceStack       []executor.Instance
 	codeHashStack       [][]byte
+	codeSizeStack       []uint64
 
 	instances map[string]executor.Instance
 }
@@ -47,6 +49,8 @@ func NewInstanceTracker() (*instanceTracker, error) {
 	tracker := &instanceTracker{
 		instances:           make(map[string]executor.Instance),
 		instanceStack:       make([]executor.Instance, 0),
+		codeHashStack:       make([][]byte, 0),
+		codeSizeStack:       make([]uint64, 0),
 		numRunningInstances: 0,
 	}
 
@@ -69,12 +73,14 @@ func (tracker *instanceTracker) InitState() {
 	tracker.instance = nil
 	tracker.codeHash = make([]byte, 0)
 	tracker.instances = make(map[string]executor.Instance)
+	tracker.codeSize = 0
 }
 
 // PushState pushes the active instance and codeHash on the state stacks
 func (tracker *instanceTracker) PushState() {
 	tracker.instanceStack = append(tracker.instanceStack, tracker.instance)
 	tracker.codeHashStack = append(tracker.codeHashStack, tracker.codeHash)
+	tracker.codeSizeStack = append(tracker.codeSizeStack, tracker.codeSize)
 	logTracker.Trace("pushing instance", "id", tracker.instance.ID(), "codeHash", tracker.codeHash)
 }
 
@@ -102,6 +108,9 @@ func (tracker *instanceTracker) PopSetActiveState() {
 	tracker.instanceStack = tracker.instanceStack[:instanceStackLen-1]
 	tracker.codeHash = tracker.codeHashStack[instanceStackLen-1]
 	tracker.codeHashStack = tracker.codeHashStack[:instanceStackLen-1]
+
+	tracker.codeSize = tracker.codeSizeStack[instanceStackLen-1]
+	tracker.codeSizeStack = tracker.codeSizeStack[:instanceStackLen-1]
 }
 
 func (tracker *instanceTracker) cleanPoppedInstance(instance executor.Instance, codeHash []byte) {
@@ -122,6 +131,7 @@ func (tracker *instanceTracker) PopDiscard() {
 func (tracker *instanceTracker) ClearStateStack() {
 	tracker.codeHashStack = make([][]byte, 0)
 	tracker.instanceStack = make([]executor.Instance, 0)
+	tracker.codeSizeStack = make([]uint64, 0)
 }
 
 // StackSize returns the size of the instance stack
@@ -268,6 +278,16 @@ func (tracker *instanceTracker) SetCodeHash(codeHash []byte) {
 	tracker.codeHash = codeHash
 }
 
+// SetCodeSize sets the size of the active code
+func (tracker *instanceTracker) SetCodeSize(codeSize uint64) {
+	tracker.codeSize = codeSize
+}
+
+// GetCodeSize returns the size of the active code
+func (tracker *instanceTracker) GetCodeSize() uint64 {
+	return tracker.codeSize
+}
+
 // SetNewInstance sets the given instance as active and tracks its creation
 func (tracker *instanceTracker) SetNewInstance(instance executor.Instance, cacheLevel instanceCacheLevel) {
 	tracker.ReplaceInstance(instance)
@@ -306,7 +326,7 @@ func (tracker *instanceTracker) UnsetInstance() {
 		"codeHash", tracker.codeHash)
 	tracker.instance = nil
 	tracker.codeHash = nil
-
+	tracker.codeSize = 0
 }
 
 // LogCounts prints the instance counter to the log

--- a/vmhost/contexts/instanceTracker_test.go
+++ b/vmhost/contexts/instanceTracker_test.go
@@ -44,11 +44,13 @@ func TestInstanceTracker_InitState(t *testing.T) {
 	require.Equal(t, 5, iTracker.numRunningInstances)
 	require.Len(t, iTracker.instances, 5)
 
+	iTracker.codeSize = 12
 	iTracker.InitState()
 
 	require.Nil(t, iTracker.instance)
 	require.Len(t, iTracker.codeHash, 0)
 	require.Len(t, iTracker.instances, 0)
+	require.Zero(t, iTracker.codeSize)
 
 	// InitState() must not reset numRunningInstances
 	require.Equal(t, 5, iTracker.numRunningInstances)

--- a/vmhost/contexts/runtime.go
+++ b/vmhost/contexts/runtime.go
@@ -27,7 +27,6 @@ type runtimeContext struct {
 	host                 vmhost.VMHost
 	vmInput              *vmcommon.ContractCallInput
 	codeAddress          []byte
-	codeSize             uint64
 	callFunction         string
 	vmType               []byte
 	readOnly             bool
@@ -145,6 +144,7 @@ func (context *runtimeContext) StartWasmerInstance(contract []byte, gasLimit uin
 		codeHash = blockchain.GetCodeHash(context.codeAddress)
 	}
 
+	context.iTracker.SetCodeSize(uint64(len(contract)))
 	context.iTracker.SetCodeHash(codeHash)
 
 	defer func() {
@@ -285,13 +285,12 @@ func (context *runtimeContext) GetSCCode() ([]byte, error) {
 		return nil, err
 	}
 
-	context.codeSize = uint64(len(code))
 	return code, nil
 }
 
 // GetSCCodeSize returns the cached size of the current SC code.
 func (context *runtimeContext) GetSCCodeSize() uint64 {
-	return context.codeSize
+	return context.iTracker.GetCodeSize()
 }
 
 func (context *runtimeContext) saveCompiledCode() {

--- a/vmhost/contexts/runtime_test.go
+++ b/vmhost/contexts/runtime_test.go
@@ -159,7 +159,6 @@ func TestRuntimeContext_NewWasmerInstance(t *testing.T) {
 	dummy = []byte("contract")
 	err = runtimeCtx.StartWasmerInstance(dummy, gasLimit, false)
 	require.NotNil(t, err)
-	require.Zero(t, runtimeCtx.GetSCCodeSize())
 
 	path := counterWasmCode
 	contractCode := vmhost.GetSCCode(path)

--- a/vmhost/hosttest/execution_test.go
+++ b/vmhost/hosttest/execution_test.go
@@ -2933,16 +2933,20 @@ func TestExecution_UpgradeContractFromExistingCode_Success(t *testing.T) {
 	test.BuildInstanceCallTest(t).
 		WithContracts(
 			test.CreateInstanceContract(sourceAddress).
+				WithOwner(test.UserAddress).
 				WithCode(sourceCode).
 				WithBalance(1000),
 			test.CreateInstanceContract(initialAddress).
+				WithOwner(test.ParentAddress).
 				WithCode(initialCode).
 				WithBalance(1000),
 			test.CreateInstanceContract(test.ParentAddress).
+				WithOwner(test.UserAddress).
 				WithCode(test.GetTestSCCode("upgrader-fromanother-contract", "../../")).
 				WithBalance(1000),
 		).
 		WithInput(test.CreateTestContractCallInputBuilder().
+			WithCallerAddr(test.UserAddress).
 			WithRecipientAddr(test.ParentAddress).
 			WithFunction("upgradeCodeFromAnotherContract").
 			WithArguments(initialAddress, sourceAddress).
@@ -3406,15 +3410,18 @@ func TestExecutionRuntimeCodeSizeUpgradeContract(t *testing.T) {
 	testCase := test.BuildInstanceCallTest(t).
 		WithContracts(
 			test.CreateInstanceContract(test.ParentAddress).
+				WithOwner(test.UserAddress).
 				WithCode(oldCode)).
 		WithInput(test.CreateTestContractCallInputBuilder().
+			WithCallerAddr(test.UserAddress).
 			WithRecipientAddr(test.ParentAddress).
 			WithGasProvided(1_000_000).
 			WithFunction("answer").
 			Build())
 
 	testCase.
-		AndAssertResultsWithoutReset(func(host vmhost.VMHost, _ *contextmock.BlockchainHookStub, _ *test.VMOutputVerifier) {
+		AndAssertResultsWithoutReset(func(host vmhost.VMHost, _ *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
+			verify.Ok()
 			require.Equal(t,
 				uint64(len(oldCode)),
 				host.Runtime().GetSCCodeSize())
@@ -3422,13 +3429,15 @@ func TestExecutionRuntimeCodeSizeUpgradeContract(t *testing.T) {
 
 	testCase.
 		WithInput(test.CreateTestContractCallInputBuilder().
+			WithCallerAddr(test.UserAddress).
 			WithRecipientAddr(test.ParentAddress).
 			WithGasProvided(1_000_000).
 			WithFunction(vmhost.UpgradeFunctionName).
 			WithArguments(newCode, test.DefaultCodeMetadata).
 			Build())
 
-	testCase.AndAssertResultsWithoutReset(func(host vmhost.VMHost, _ *contextmock.BlockchainHookStub, _ *test.VMOutputVerifier) {
+	testCase.AndAssertResultsWithoutReset(func(host vmhost.VMHost, _ *contextmock.BlockchainHookStub, verify *test.VMOutputVerifier) {
+		verify.Ok()
 		require.Equal(t,
 			expectedCodeSize,
 			host.Runtime().GetSCCodeSize())


### PR DESCRIPTION
This PR replicates for v1.5 the changes brought by https://github.com/multiversx/mx-chain-vm-v1_4-go/pull/42 for v1.4, namely the fix for `runtimeContext.codeSize`.