### PR TITLE
Fix test executor switch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,15 @@ endif
 
 test:
 	go clean -cache -testcache
-	export VMEXECUTOR="wasmer1"
-	go test ./...
+	VMEXECUTOR="wasmer1" go test ./...
 	go clean -cache -testcache
-	export VMEXECUTOR="wasmer2"
-	go test ./...
+	VMEXECUTOR="wasmer2" go test ./...
+
+test-w1: clean
+	VMEXECUTOR="wasmer1" go test ./...
+
+test-w2: clean
+	VMEXECUTOR="wasmer2" go test ./...
 
 test-v: clean
 	go test ./... -v

--- a/integrationTests/features/pureFunctionUtil.go
+++ b/integrationTests/features/pureFunctionUtil.go
@@ -158,6 +158,11 @@ func (pfe *pureFunctionExecutor) executePureFunctionTests(t *testing.T,
 	resultInterpreter resultInterpreter,
 	logProgress logProgress) {
 
+	defer func() {
+		vmHost := pfe.vm.(vmhost.VMHost)
+		vmHost.Reset()
+	}()
+
 	// RUN!
 	for testCaseIndex, testCase := range testCases {
 		if logProgress != nil {
@@ -169,8 +174,5 @@ func (pfe *pureFunctionExecutor) executePureFunctionTests(t *testing.T,
 
 		err = pfe.checkTxResults(testCase, output, resultInterpreter)
 		require.Nil(t, err)
-
-		vmHost := pfe.vm.(vmhost.VMHost)
-		vmHost.Reset()
 	}
 }

--- a/integrationTests/json/scenariosExecutorLogs_test.go
+++ b/integrationTests/json/scenariosExecutorLogs_test.go
@@ -3,11 +3,15 @@ package vmjsonintegrationtest
 import (
 	"testing"
 
+	"github.com/multiversx/mx-chain-vm-go/testcommon/testexecutor"
 	"github.com/multiversx/mx-chain-vm-go/wasmer"
 	"github.com/multiversx/mx-chain-vm-go/wasmer2"
 )
 
 func TestRustCompareAdderLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
 	expected := ScenariosTest(t).
 		Folder("adder/scenarios").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -26,6 +30,10 @@ func TestRustCompareAdderLog(t *testing.T) {
 }
 
 func TestRustFactorialLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("factorial/scenarios").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -44,6 +52,10 @@ func TestRustFactorialLog(t *testing.T) {
 }
 
 func TestRustErc20Log(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	t.Skip("not a working test")
 
 	expected := ScenariosTest(t).
@@ -64,6 +76,10 @@ func TestRustErc20Log(t *testing.T) {
 }
 
 func TestCErc20Log(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("erc20-c").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -82,6 +98,10 @@ func TestCErc20Log(t *testing.T) {
 }
 
 func TestDigitalCashLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("digital-cash").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -100,6 +120,10 @@ func TestDigitalCashLog(t *testing.T) {
 }
 
 func TestESDTMultiTransferOnCallbackLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("features/composability/scenarios").
 		File("forw_raw_call_async_retrieve_multi_transfer.scen.json").
@@ -120,6 +144,10 @@ func TestESDTMultiTransferOnCallbackLog(t *testing.T) {
 }
 
 func TestCreateAsyncCallLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	t.Skip("not a working test")
 
 	expected := ScenariosTest(t).
@@ -142,6 +170,10 @@ func TestCreateAsyncCallLog(t *testing.T) {
 }
 
 func TestESDTMultiTransferOnCallAndCallbackLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("features/composability/scenarios").
 		File("forw_raw_async_send_and_retrieve_multi_transfer_funds.scen.json").
@@ -162,6 +194,10 @@ func TestESDTMultiTransferOnCallAndCallbackLog(t *testing.T) {
 }
 
 func TestMultisigLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	t.Skip("not a working test")
 
 	expected := ScenariosTest(t).
@@ -182,6 +218,10 @@ func TestMultisigLog(t *testing.T) {
 }
 
 func TestDnsContractLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	t.Skip("not a working test")
 
 	if testing.Short() {
@@ -206,6 +246,10 @@ func TestDnsContractLog(t *testing.T) {
 }
 
 func TestCrowdfundingEsdtLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("crowdfunding-esdt").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -224,6 +268,10 @@ func TestCrowdfundingEsdtLog(t *testing.T) {
 }
 
 func TestEgldEsdtSwapLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("egld-esdt-swap").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -242,6 +290,10 @@ func TestEgldEsdtSwapLog(t *testing.T) {
 }
 
 func TestPingPongEgldLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	expected := ScenariosTest(t).
 		Folder("ping-pong-egld").
 		WithExecutorFactory(wasmer.ExecutorFactory()).
@@ -260,6 +312,10 @@ func TestPingPongEgldLog(t *testing.T) {
 }
 
 func TestRustAttestationLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	if testing.Short() {
 		t.Skip("not a short test")
 	}
@@ -282,6 +338,10 @@ func TestRustAttestationLog(t *testing.T) {
 }
 
 func TestCAttestationLog(t *testing.T) {
+	if !testexecutor.IsWasmer1Allowed() {
+		t.Skip("run exclusively with wasmer1")
+	}
+
 	if testing.Short() {
 		t.Skip("not a short test")
 	}

--- a/testcommon/testexecutor/defaultTestExecutor.go
+++ b/testcommon/testexecutor/defaultTestExecutor.go
@@ -11,16 +11,25 @@ import (
 	"github.com/multiversx/mx-chain-vm-go/wasmer2"
 )
 
-var defaultExecutorString = "wasmer1"
+// EnvVMEXECUTOR is the name of the environment variable that controls the default test executor
+var EnvVMEXECUTOR = "VMEXECUTOR"
 
-// NewDefaultTestExecutorFactory instantiates an executor factory based on a CLI flag specified to `go test`
+// ExecWasmer1 is the value of the EnvVMEXECUTOR variable which selects Wasmer 1
+var ExecWasmer1 = "wasmer1"
+
+// ExecWasmer2 is the value of the EnvVMEXECUTOR variable which selects Wasmer 2
+var ExecWasmer2 = "wasmer2"
+
+var defaultExecutorString = ExecWasmer2
+
+// NewDefaultTestExecutorFactory instantiates an executor factory based on the $VMEXECUTOR environment variable
 func NewDefaultTestExecutorFactory(tb testing.TB) executor.ExecutorAbstractFactory {
 	execStr := getVMExecutorString()
 
-	if execStr == "wasmer1" {
+	if execStr == ExecWasmer1 {
 		return wasmer.ExecutorFactory()
 	}
-	if execStr == "wasmer2" {
+	if execStr == ExecWasmer2 {
 		return wasmer2.ExecutorFactory()
 	}
 
@@ -32,8 +41,15 @@ func NewDefaultTestExecutorFactory(tb testing.TB) executor.ExecutorAbstractFacto
 	return nil
 }
 
+// IsWasmer1Allowed returns true if the default test executor is Wasmer 1.
+// If the default test executor is Wasmer 2, it is not allowed to instantiate a
+// Wasmer 1 executor due to low-level conflicts between Wasmer 1 and 2.
+func IsWasmer1Allowed() bool {
+	return getVMExecutorString() == ExecWasmer1
+}
+
 func getVMExecutorString() string {
-	execStr := os.Getenv("VMEXECUTOR")
+	execStr := os.Getenv(EnvVMEXECUTOR)
 
 	if len(execStr) == 0 {
 		execStr = defaultExecutorString


### PR DESCRIPTION
This PR fixes the `Makefile` and adds a skipping condition to the tests that require both Wasmer 1 and Wasmer 2 in the same run. This condition only allows the tests to run when `wasmer1` is selected, to avoid conflicts. The tests are just as meaningful as before.