### PR TITLE
EI - big int to small int explicit error if it doesn't fit

### DIFF
--- a/vmhost/errors.go
+++ b/vmhost/errors.go
@@ -119,6 +119,9 @@ var ErrStorageValueOutOfRange = errors.New("storage value out of range")
 var ErrDivZero = errors.New("division by 0")
 
 // ErrBitwiseNegative signals that an attempt to apply a bitwise operation on negative numbers has been made
+var ErrBigIntCannotBeRepresentedAsInt64 = errors.New("big int cannot be represented as int64")
+
+// ErrBitwiseNegative signals that an attempt to apply a bitwise operation on negative numbers has been made
 var ErrBitwiseNegative = errors.New("bitwise operations only allowed on positive integers")
 
 // ErrShiftNegative signals that an attempt to apply a bitwise shift operation on negative numbers has been made

--- a/vmhost/vmhooks/bigIntOps.go
+++ b/vmhost/vmhooks/bigIntOps.go
@@ -414,11 +414,17 @@ func (context *VMHooksImpl) BigIntIsInt64(destinationHandle int32) int32 {
 func (context *VMHooksImpl) BigIntGetInt64(destinationHandle int32) int64 {
 	managedType := context.GetManagedTypesContext()
 	metering := context.GetMeteringContext()
+	runtime := context.GetRuntimeContext()
 
 	gasToUse := metering.GasSchedule().BigIntAPICost.BigIntGetInt64
 	metering.UseGasAndAddTracedGas(bigIntGetInt64Name, gasToUse)
 
 	value := managedType.GetBigIntOrCreate(destinationHandle)
+	if !value.IsInt64() {
+		if context.WithFault(vmhost.ErrBigIntCannotBeRepresentedAsInt64, runtime.BigIntAPIErrorShouldFailExecution()) {
+			return -1
+		}
+	}
 	return value.Int64()
 }
 


### PR DESCRIPTION
Quoting from the documentation:
```
func (*big.Int).Int64() int64
Int64 returns the int64 representation of x. If x cannot be represented in an int64, the result is undefined.

(big.Int).Int64 on pkg.go.dev
```

We don't like undefined behavior, so we replaced it with an explicit error.