### PR TITLE
mockESDT missing account error handling

### DIFF
--- a/mock/world/mockESDT.go
+++ b/mock/world/mockESDT.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 
 	"github.com/multiversx/mx-chain-core-go/core"
+	"github.com/multiversx/mx-chain-core-go/core/check"
 	"github.com/multiversx/mx-chain-core-go/data/esdt"
 	"github.com/multiversx/mx-chain-core-go/data/vm"
 	"github.com/multiversx/mx-chain-scenario-go/esdtconvert"
@@ -17,7 +18,7 @@ import (
 // key (token keys are built from the token identifier using MakeTokenKey).
 func (bf *BuiltinFunctionsWrapper) GetTokenBalance(address []byte, tokenIdentifier []byte, nonce uint64) (*big.Int, error) {
 	account := bf.World.AcctMap.GetAccount(address)
-	if account == nil {
+	if check.IfNil(account) {
 		return nil, fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
 	}
 	return esdtconvert.GetTokenBalance(tokenIdentifier, nonce, account.Storage)
@@ -27,7 +28,7 @@ func (bf *BuiltinFunctionsWrapper) GetTokenBalance(address []byte, tokenIdentifi
 // (token keys are built from the token identifier using MakeTokenKey).
 func (bf *BuiltinFunctionsWrapper) GetTokenData(address []byte, tokenIdentifier []byte, nonce uint64) (*esdt.ESDigitalToken, error) {
 	account := bf.World.AcctMap.GetAccount(address)
-	if account == nil {
+	if check.IfNil(account) {
 		return nil, fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
 	}
 	systemAccStorage := make(map[string][]byte)
@@ -42,7 +43,7 @@ func (bf *BuiltinFunctionsWrapper) GetTokenData(address []byte, tokenIdentifier 
 // (token keys are built from the token identifier using MakeTokenKey).
 func (bf *BuiltinFunctionsWrapper) SetTokenData(address []byte, tokenIdentifier []byte, nonce uint64, tokenData *esdt.ESDigitalToken) error {
 	account := bf.World.AcctMap.GetAccount(address)
-	if account == nil {
+	if check.IfNil(account) {
 		return fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
 	}
 	return account.SetTokenData(tokenIdentifier, nonce, tokenData)

--- a/mock/world/mockESDT.go
+++ b/mock/world/mockESDT.go
@@ -1,7 +1,6 @@
 package worldmock
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -19,7 +18,7 @@ import (
 func (bf *BuiltinFunctionsWrapper) GetTokenBalance(address []byte, tokenIdentifier []byte, nonce uint64) (*big.Int, error) {
 	account := bf.World.AcctMap.GetAccount(address)
 	if check.IfNil(account) {
-		return nil, fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
+		return big.NewInt(0), nil
 	}
 	return esdtconvert.GetTokenBalance(tokenIdentifier, nonce, account.Storage)
 }
@@ -29,7 +28,9 @@ func (bf *BuiltinFunctionsWrapper) GetTokenBalance(address []byte, tokenIdentifi
 func (bf *BuiltinFunctionsWrapper) GetTokenData(address []byte, tokenIdentifier []byte, nonce uint64) (*esdt.ESDigitalToken, error) {
 	account := bf.World.AcctMap.GetAccount(address)
 	if check.IfNil(account) {
-		return nil, fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
+		return &esdt.ESDigitalToken{
+			Value: big.NewInt(0),
+		}, nil
 	}
 	systemAccStorage := make(map[string][]byte)
 	systemAcc := bf.World.AcctMap.GetAccount(vmcommon.SystemAccountAddress)
@@ -44,7 +45,7 @@ func (bf *BuiltinFunctionsWrapper) GetTokenData(address []byte, tokenIdentifier 
 func (bf *BuiltinFunctionsWrapper) SetTokenData(address []byte, tokenIdentifier []byte, nonce uint64, tokenData *esdt.ESDigitalToken) error {
 	account := bf.World.AcctMap.GetAccount(address)
 	if check.IfNil(account) {
-		return fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
+		return nil
 	}
 	return account.SetTokenData(tokenIdentifier, nonce, tokenData)
 }

--- a/mock/world/mockESDT.go
+++ b/mock/world/mockESDT.go
@@ -1,6 +1,7 @@
 package worldmock
 
 import (
+	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -16,6 +17,9 @@ import (
 // key (token keys are built from the token identifier using MakeTokenKey).
 func (bf *BuiltinFunctionsWrapper) GetTokenBalance(address []byte, tokenIdentifier []byte, nonce uint64) (*big.Int, error) {
 	account := bf.World.AcctMap.GetAccount(address)
+	if account == nil {
+		return nil, fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
+	}
 	return esdtconvert.GetTokenBalance(tokenIdentifier, nonce, account.Storage)
 }
 
@@ -23,6 +27,9 @@ func (bf *BuiltinFunctionsWrapper) GetTokenBalance(address []byte, tokenIdentifi
 // (token keys are built from the token identifier using MakeTokenKey).
 func (bf *BuiltinFunctionsWrapper) GetTokenData(address []byte, tokenIdentifier []byte, nonce uint64) (*esdt.ESDigitalToken, error) {
 	account := bf.World.AcctMap.GetAccount(address)
+	if account == nil {
+		return nil, fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
+	}
 	systemAccStorage := make(map[string][]byte)
 	systemAcc := bf.World.AcctMap.GetAccount(vmcommon.SystemAccountAddress)
 	if systemAcc != nil {
@@ -35,6 +42,9 @@ func (bf *BuiltinFunctionsWrapper) GetTokenData(address []byte, tokenIdentifier 
 // (token keys are built from the token identifier using MakeTokenKey).
 func (bf *BuiltinFunctionsWrapper) SetTokenData(address []byte, tokenIdentifier []byte, nonce uint64, tokenData *esdt.ESDigitalToken) error {
 	account := bf.World.AcctMap.GetAccount(address)
+	if account == nil {
+		return fmt.Errorf("account does not exist: %s", hex.EncodeToString(address))
+	}
 	return account.SetTokenData(tokenIdentifier, nonce, tokenData)
 }
 

--- a/test/features/composability/scenarios/forwarder_get_esdt_token_data.scen.json
+++ b/test/features/composability/scenarios/forwarder_get_esdt_token_data.scen.json
@@ -168,6 +168,33 @@
         },
         {
             "step": "scQuery",
+            "id": "missing-account",
+            "tx": {
+                "to": "sc:forwarder",
+                "function": "get_esdt_token_data",
+                "arguments": [
+                    "address:missing-account",
+                    "str:FUNG-00001",
+                    "0"
+                ]
+            },
+            "expect": {
+                "out": [
+                    "0",
+                    "0",
+                    "false",
+                    "",
+                    "",
+                    "",
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                    "",
+                    ""
+                ],
+                "status": "0"
+            }
+        },
+        {
+            "step": "scQuery",
             "id": "missing-token",
             "tx": {
                 "to": "sc:forwarder",


### PR DESCRIPTION
The debugger was throwing some ugly errors when trying to read ESDT data from an account that doesn't exist.