### PR TITLE
fixed scenario event log testing after merge

### DIFF
--- a/scenarioexec/stepCheckTxResult.go
+++ b/scenarioexec/stepCheckTxResult.go
@@ -118,14 +118,13 @@ func (ae *VMTestExecutor) checkTxLog(
 			checkBytesListPretty(expectedLog.Topics),
 			ae.exprReconstructor.ReconstructList(actualLog.Topics, er.NoHint))
 	}
-	//TODO fix this when integrating feat/logEvents
-	//if !expectedLog.Data.CheckList(actualLog.Data) {
-	//	return fmt.Errorf("bad log data. Tx '%s'. Log index: %d. Want:\n%s\nGot:\n%s",
-	//		txIndex,
-	//		logIndex,
-	//		mjwrite.LogToString(expectedLog),
-	//		mjwrite.LogToString(ae.convertLogToTestFormat(actualLog)))
-	//}
+	if !expectedLog.Data.CheckList(actualLog.Data) {
+		return fmt.Errorf("bad log data. Tx '%s'. Log index: %d. Want:\n%s\nGot:\n%s",
+			txIndex,
+			logIndex,
+			mjwrite.LogToString(expectedLog),
+			mjwrite.LogToString(ae.convertLogToTestFormat(actualLog)))
+	}
 	return nil
 }
 

--- a/scenarioexec/util.go
+++ b/scenarioexec/util.go
@@ -159,8 +159,7 @@ func (ae *VMTestExecutor) convertLogToTestFormat(outputLog *vmcommon.LogEntry) *
 			outputLog.Identifier,
 			ae.exprReconstructor.Reconstruct(outputLog.Identifier,
 				er.StrHint)),
-		//TODO fix this when integrating feat/logEvents
-		// Data:   dataField,
+		Data:   dataField,
 		Topics: topics,
 	}
 


### PR DESCRIPTION
TODOs were left after an incomplete merge. Log data field check has been skipped for a little while, re-enabled.