### PR TITLE
fix: fix slice init length

### DIFF
--- a/vmhost/helpers.go
+++ b/vmhost/helpers.go
@@ -63,7 +63,7 @@ func PadBytesLeft(data []byte, size int) []byte {
 		return data
 	}
 
-	paddedBytes := make([]byte, padSize)
+	paddedBytes := make([]byte, 0, padSize)
 	paddedBytes = append(paddedBytes, data...)
 	return paddedBytes
 }


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of   `padSize`   rather than initializing the length of this slice.

The online demo: https://go.dev/play/p/q1BcVCmvidW