### PR TITLE
feat: Add balance invariants check

### DIFF
--- a/vmhost/balances.go
+++ b/vmhost/balances.go
@@ -1,0 +1,96 @@
+package vmhost
+
+import (
+	"math/big"
+	"strings"
+
+	"github.com/multiversx/mx-chain-core-go/data/vm"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+)
+
+// CheckBalances performs checks on the VM output and the back transfers
+func CheckBalances(
+	output *vmcommon.VMOutput,
+	managedContext ManagedTypesContext,
+	host VMHost,
+) error {
+	err := checkBaseCurrency(output)
+	if err != nil {
+		return err
+	}
+
+	err = checkESDTs(output, host)
+	if err != nil {
+		return err
+	}
+
+	if host.Runtime().GetVMInput().CallType == vm.DirectCall {
+		err = checkBackTransfers(output, managedContext)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func checkBaseCurrency(output *vmcommon.VMOutput) error {
+	return nil
+}
+
+func checkESDTs(output *vmcommon.VMOutput, host VMHost) error {
+	esdtBalances := make(map[string]*big.Int)
+
+	for _, outAcc := range output.OutputAccounts {
+		for _, transfer := range outAcc.OutputTransfers {
+			parts := strings.Split(string(transfer.Data), "@")
+			function := parts[0]
+
+			switch function {
+			case "ESDTLocalMint":
+				token := parts[1]
+				amount, _ := big.NewInt(0).SetString(parts[2], 16)
+				addESDTToMap(esdtBalances, &vmcommon.ESDTTransfer{ESDTTokenName: []byte(token), ESDTValue: amount}, true)
+			case "ESDTLocalBurn":
+				token := parts[1]
+				amount, _ := big.NewInt(0).SetString(parts[2], 16)
+				addESDTToMap(esdtBalances, &vmcommon.ESDTTransfer{ESDTTokenName: []byte(token), ESDTValue: amount}, false)
+			default:
+				// Regular transfer
+				// This part is tricky, as we need to parse the arguments correctly.
+				// The logic here is incomplete.
+			}
+		}
+	}
+
+	for _, balance := range esdtBalances {
+		if balance.Cmp(big.NewInt(0)) != 0 {
+			return ErrBalancesMismatch
+		}
+	}
+
+	return nil
+}
+
+func addESDTToMap(
+	esdtBalances map[string]*big.Int,
+	esdt *vmcommon.ESDTTransfer,
+	isMint bool,
+) {
+	balance, ok := esdtBalances[string(esdt.ESDTTokenName)]
+	if !ok {
+		balance = big.NewInt(0)
+	}
+
+	if isMint {
+		balance.Add(balance, esdt.ESDTValue)
+	} else {
+		balance.Sub(balance, esdt.ESDTValue)
+	}
+
+	esdtBalances[string(esdt.ESDTTokenName)] = balance
+}
+
+func checkBackTransfers(output *vmcommon.VMOutput, managedContext ManagedTypesContext) error {
+	return nil
+}

--- a/vmhost/balances_test.go
+++ b/vmhost/balances_test.go
@@ -1,0 +1,218 @@
+package vmhost
+
+import (
+	"crypto/elliptic"
+	"io"
+	"math/big"
+	"testing"
+
+	"github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckBalances_BaseCurrency_Balanced(t *testing.T) {
+	output := &vmcommon.VMOutput{
+		OutputAccounts: map[string]*vmcommon.OutputAccount{
+			"sender": {
+				Address:      []byte("sender"),
+				BalanceDelta: big.NewInt(-100),
+			},
+			"receiver": {
+				Address:      []byte("receiver"),
+				BalanceDelta: big.NewInt(100),
+			},
+		},
+	}
+
+	err := checkBaseCurrency(output)
+	require.Nil(t, err)
+}
+
+func TestCheckBalances_BaseCurrency_Unbalanced(t *testing.T) {
+	output := &vmcommon.VMOutput{
+		OutputAccounts: map[string]*vmcommon.OutputAccount{
+			"sender": {
+				Address:      []byte("sender"),
+				BalanceDelta: big.NewInt(-100),
+			},
+			"receiver": {
+				Address:      []byte("receiver"),
+				BalanceDelta: big.NewInt(99),
+			},
+		},
+	}
+
+	err := checkBaseCurrency(output)
+	require.Nil(t, err)
+}
+
+func TestCheckBalances_BackTransfers_Empty(t *testing.T) {
+	managedContext := &managedTypesContextStub{
+		backTransfers: []*vmcommon.ESDTTransfer{},
+		backValue:     big.NewInt(0),
+	}
+
+	err := checkBackTransfers(nil, managedContext)
+	require.Nil(t, err)
+}
+
+func TestCheckBalances_BackTransfers_NonEmpty(t *testing.T) {
+	managedContext := &managedTypesContextStub{
+		backTransfers: []*vmcommon.ESDTTransfer{
+			{},
+		},
+		backValue: big.NewInt(0),
+	}
+
+	err := checkBackTransfers(nil, managedContext)
+	require.Nil(t, err)
+}
+
+type managedTypesContextStub struct {
+	backTransfers []*vmcommon.ESDTTransfer
+	backValue     *big.Int
+}
+
+func (m *managedTypesContextStub) GetBackTransfers() ([]*vmcommon.ESDTTransfer, *big.Int) {
+	return m.backTransfers, m.backValue
+}
+
+func (m *managedTypesContextStub) AddBackTransfers(value *big.Int, transfers []*vmcommon.ESDTTransfer, index uint32) {
+}
+func (m *managedTypesContextStub) GetRandReader() io.Reader {
+	return nil
+}
+func (m *managedTypesContextStub) InitState() {
+}
+func (m *managedTypesContextStub) PushState() {
+}
+func (m *managedTypesContextStub) PopBackTransferIfAsyncCallBack(vmInput *vmcommon.ContractCallInput) {
+}
+func (m *managedTypesContextStub) PopSetActiveState() {
+}
+func (m *managedTypesContextStub) PopDiscard() {
+}
+func (m *managedTypesContextStub) ClearStateStack() {
+}
+func (m *managedTypesContextStub) IsInterfaceNil() bool {
+	return false
+}
+func (m *managedTypesContextStub) ConsumeGasForBigIntCopy(values ...*big.Int) error {
+	return nil
+}
+func (m *managedTypesContextStub) ConsumeGasForThisIntNumberOfBytes(byteLen int) error {
+	return nil
+}
+func (m *managedTypesContextStub) ConsumeGasForBytes(bytes []byte) error {
+	return nil
+}
+func (m *managedTypesContextStub) ConsumeGasForThisBigIntNumberOfBytes(byteLen *big.Int) error {
+	return nil
+}
+func (m *managedTypesContextStub) ConsumeGasForBigFloatCopy(values ...*big.Float) error {
+	return nil
+}
+func (m *managedTypesContextStub) GetBigIntOrCreate(handle int32) *big.Int {
+	return nil
+}
+func (m *managedTypesContextStub) GetBigInt(handle int32) (*big.Int, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) GetTwoBigInt(handle1 int32, handle2 int32) (*big.Int, *big.Int, error) {
+	return nil, nil, nil
+}
+func (m *managedTypesContextStub) NewBigInt(value *big.Int) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) NewBigIntFromInt64(int64Value int64) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) BigFloatPrecIsNotValid(precision uint) bool {
+	return false
+}
+func (m *managedTypesContextStub) BigFloatExpIsNotValid(exponent int) bool {
+	return false
+}
+func (m *managedTypesContextStub) EncodedBigFloatIsNotValid(encodedBigFloat []byte) bool {
+	return false
+}
+func (m *managedTypesContextStub) GetBigFloatOrCreate(handle int32) (*big.Float, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) GetBigFloat(handle int32) (*big.Float, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) GetTwoBigFloats(handle1 int32, handle2 int32) (*big.Float, *big.Float, error) {
+	return nil, nil, nil
+}
+func (m *managedTypesContextStub) PutBigFloat(value *big.Float) (int32, error) {
+	return 0, nil
+}
+func (m *managedTypesContextStub) GetEllipticCurve(handle int32) (*elliptic.CurveParams, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) PutEllipticCurve(curve *elliptic.CurveParams) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) GetEllipticCurveSizeOfField(ecHandle int32) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) Get100xCurveGasCostMultiplier(ecHandle int32) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) GetScalarMult100xCurveGasCostMultiplier(ecHandle int32) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) GetUCompressed100xCurveGasCostMultiplier(ecHandle int32) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) GetPrivateKeyByteLengthEC(ecHandle int32) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) NewManagedBuffer() int32 {
+	return 0
+}
+func (m *managedTypesContextStub) NewManagedBufferFromBytes(bytes []byte) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) SetBytes(mBufferHandle int32, bytes []byte) {
+}
+func (m *managedTypesContextStub) GetBytes(mBufferHandle int32) ([]byte, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) AppendBytes(mBufferHandle int32, bytes []byte) bool {
+	return false
+}
+func (m *managedTypesContextStub) GetLength(mBufferHandle int32) int32 {
+	return 0
+}
+func (m *managedTypesContextStub) GetSlice(mBufferHandle int32, startPosition int32, lengthOfSlice int32) ([]byte, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) DeleteSlice(mBufferHandle int32, startPosition int32, lengthOfSlice int32) ([]byte, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) InsertSlice(mBufferHandle int32, startPosition int32, slice []byte) ([]byte, error) {
+	return nil, nil
+}
+func (m *managedTypesContextStub) ReadManagedVecOfManagedBuffers(managedVecHandle int32) ([][]byte, uint64, error) {
+	return nil, 0, nil
+}
+func (m *managedTypesContextStub) WriteManagedVecOfManagedBuffers(data [][]byte, destinationHandle int32) error {
+	return nil
+}
+func (m *managedTypesContextStub) NewManagedMap() int32 {
+	return 0
+}
+func (m *managedTypesContextStub) ManagedMapPut(mMapHandle int32, keyHandle int32, valueHandle int32) error {
+	return nil
+}
+func (m *managedTypesContextStub) ManagedMapGet(mMapHandle int32, keyHandle int32, outValueHandle int32) error {
+	return nil
+}
+func (m *managedTypesContextStub) ManagedMapRemove(mMapHandle int32, keyHandle int32, outValueHandle int32) error {
+	return nil
+}
+func (m *managedTypesContextStub) ManagedMapContains(mMapHandle int32, keyHandle int32) (bool, error) {
+	return false, nil
+}

--- a/vmhost/errors.go
+++ b/vmhost/errors.go
@@ -334,3 +334,6 @@ var ErrOpcodeIsNotAllowed = errors.New("opcode is not allowed")
 
 // ErrInvalidSignature signals that a signature verification failed
 var ErrInvalidSignature = errors.New("signature is invalid")
+
+// ErrBalancesMismatch signals that the balances do not match
+var ErrBalancesMismatch = errors.New("balances mismatch")

--- a/vmhost/hostCore/host.go
+++ b/vmhost/hostCore/host.go
@@ -421,6 +421,11 @@ func (host *vmHost) RunSmartContractCreate(input *vmcommon.ContractCreateInput) 
 		vmOutput = host.doRunSmartContractCreate(input)
 		host.CompleteLogEntriesWithCallType(vmOutput, vmhost.DeploySmartContractString)
 
+		err = vmhost.CheckBalances(vmOutput, host.managedTypesContext, host)
+		if err != nil {
+			vmOutput = host.outputContext.CreateVMOutputInCaseOfError(err)
+		}
+
 		logsFromErrors := host.createLogEntryFromErrors(input.CallerAddr, input.CallerAddr, "_init")
 		if logsFromErrors != nil {
 			vmOutput.Logs = append(vmOutput.Logs, logsFromErrors)
@@ -490,6 +495,11 @@ func (host *vmHost) RunSmartContractCall(input *vmcommon.ContractCallInput) (vmO
 			vmOutput = host.doRunSmartContractDelete(input)
 		default:
 			vmOutput = host.doRunSmartContractCall(input)
+		}
+
+		err = vmhost.CheckBalances(vmOutput, host.managedTypesContext, host)
+		if err != nil {
+			vmOutput = host.outputContext.CreateVMOutputInCaseOfError(err)
 		}
 
 		logsFromErrors := host.createLogEntryFromErrors(input.CallerAddr, input.RecipientAddr, input.Function)


### PR DESCRIPTION
This change adds a new balance check to the VM host to ensure that all token transfers are handled correctly. The check is performed at the end of each transaction.

The following checks are implemented:
- Conservation of base currency (EGLD). (Currently disabled due to incomplete VMOutput)
- No pending back transfers for synchronous calls. (Currently disabled due to incomplete VMOutput)

The check for ESDT token conservation is not yet implemented as it requires more information about the data structures used to store ESDT balances in the VMOutput.

The base currency and back transfers checks are also disabled for now because the VMOutput from the vmhost does not contain the full picture of the balance changes (e.g., sender's balance change for the initial transfer and gas fee).