### PR TITLE
feat: Add unsafe execution mode

### DIFF
--- a/executor/vmHooks.go
+++ b/executor/vmHooks.go
@@ -16,6 +16,7 @@ type VMHooks interface {
 	ManagedMapVMHooks
 	SmallIntVMHooks
 	CryptoVMHooks
+	UnsafeVMHooks
 }
 
 type MainVMHooks interface {
@@ -317,4 +318,9 @@ type CryptoVMHooks interface {
 	ManagedVerifySecp256r1(keyHandle int32, messageHandle int32, sigHandle int32) int32
 	ManagedVerifyBLSSignatureShare(keyHandle int32, messageHandle int32, sigHandle int32) int32
 	ManagedVerifyBLSAggregatedSignature(keyHandle int32, messageHandle int32, sigHandle int32) int32
+}
+
+type UnsafeVMHooks interface {
+	ActivateUnsafeMode()
+	DeactivateUnsafeMode()
 }

--- a/executor/wrapper/wrapperVMHooks.go
+++ b/executor/wrapper/wrapperVMHooks.go
@@ -2409,3 +2409,19 @@ func (w *WrapperVMHooks) ManagedVerifyBLSAggregatedSignature(keyHandle int32, me
 	w.logger.LogVMHookCallAfter(callInfo)
 	return result
 }
+
+// ActivateUnsafeMode VM hook wrapper
+func (w *WrapperVMHooks) ActivateUnsafeMode() {
+	callInfo := "ActivateUnsafeMode()"
+	w.logger.LogVMHookCallBefore(callInfo)
+	w.wrappedVMHooks.ActivateUnsafeMode()
+	w.logger.LogVMHookCallAfter(callInfo)
+}
+
+// DeactivateUnsafeMode VM hook wrapper
+func (w *WrapperVMHooks) DeactivateUnsafeMode() {
+	callInfo := "DeactivateUnsafeMode()"
+	w.logger.LogVMHookCallBefore(callInfo)
+	w.wrappedVMHooks.DeactivateUnsafeMode()
+	w.logger.LogVMHookCallAfter(callInfo)
+}

--- a/mock/context/executorMockFunc.go
+++ b/mock/context/executorMockFunc.go
@@ -286,4 +286,6 @@ var functionNames = map[string]struct{}{
 	"managedVerifySecp256r1":                       empty,
 	"managedVerifyBLSSignatureShare":               empty,
 	"managedVerifyBLSAggregatedSignature":          empty,
+	"activateUnsafeMode":                           empty,
+	"deactivateUnsafeMode":                         empty,
 }

--- a/mock/context/runtimeContextMock.go
+++ b/mock/context/runtimeContextMock.go
@@ -324,6 +324,10 @@ func (r *RuntimeContextMock) UseGasBoundedShouldFailExecution() bool {
 func (r *RuntimeContextMock) FailExecution(_ error) {
 }
 
+// FailExecutionConditionally mocked method
+func (r *RuntimeContextMock) FailExecutionConditionally(_ error) {
+}
+
 // AddAsyncContextCall mocked method
 func (r *RuntimeContextMock) AddAsyncContextCall(_ []byte, _ *vmhost.AsyncGeneratedCall) error {
 	return r.Err

--- a/mock/context/runtimeContextWrapper.go
+++ b/mock/context/runtimeContextWrapper.go
@@ -389,6 +389,11 @@ func (contextWrapper *RuntimeContextWrapper) FailExecution(err error) {
 	contextWrapper.FailExecutionFunc(err)
 }
 
+// FailExecutionConditionally calls corresponding xxxFunc function, that by default in turn calls the original method of the wrapped RuntimeContext
+func (contextWrapper *RuntimeContextWrapper) FailExecutionConditionally(err error) {
+	contextWrapper.runtimeContext.FailExecutionConditionally(err)
+}
+
 // MustVerifyNextContractCode calls corresponding xxxFunc function, that by default in turn calls the original method of the wrapped RuntimeContext
 func (contextWrapper *RuntimeContextWrapper) MustVerifyNextContractCode() {
 	contextWrapper.MustVerifyNextContractCodeFunc()

--- a/mock/context/vmHostMock.go
+++ b/mock/context/vmHostMock.go
@@ -265,3 +265,16 @@ func (host *VMHostMock) SetGasTracing(enableGasTracing bool) {
 func (host *VMHostMock) GetGasTrace() map[string]map[string][]uint64 {
 	return make(map[string]map[string][]uint64)
 }
+
+// SetUnsafeMode -
+func (host *VMHostMock) SetUnsafeMode(unsafeMode bool) {
+}
+
+// IsUnsafeMode -
+func (host *VMHostMock) IsUnsafeMode() bool {
+	return false
+}
+
+// FailExecutionConditionally -
+func (host *VMHostMock) FailExecutionConditionally(err error) {
+}

--- a/mock/context/vmHostStub.go
+++ b/mock/context/vmHostStub.go
@@ -333,3 +333,16 @@ func (vhs *VMHostStub) SetGasTracing(enableGasTracing bool) {
 func (vhs *VMHostStub) GetGasTrace() map[string]map[string][]uint64 {
 	return make(map[string]map[string][]uint64)
 }
+
+// SetUnsafeMode -
+func (host *VMHostStub) SetUnsafeMode(unsafeMode bool) {
+}
+
+// IsUnsafeMode -
+func (host *VMHostStub) IsUnsafeMode() bool {
+	return false
+}
+
+// FailExecutionConditionally -
+func (host *VMHostStub) FailExecutionConditionally(err error) {
+}

--- a/mock/unsafeVmHostMock.go
+++ b/mock/unsafeVmHostMock.go
@@ -1,0 +1,261 @@
+package mock
+
+import (
+	"github.com/multiversx/mx-chain-core-go/data/vm"
+	vmcommon "github.com/multiversx/mx-chain-vm-common-go"
+	"github.com/multiversx/mx-chain-vm-go/config"
+	"github.com/multiversx/mx-chain-vm-go/crypto"
+	"github.com/multiversx/mx-chain-vm-go/vmhost"
+)
+
+// UnsafeVMHostMock is a mock for the VMHost interface that helps testing the unsafe mode
+type UnsafeVMHostMock struct {
+	unsafeMode            bool
+	FailExecutionCalled   bool
+	FailConditionallyCalled bool
+	BreakpointValue       vmhost.BreakpointValue
+	meteringContext       vmhost.MeteringContext
+	runtimeContext        vmhost.RuntimeContext
+}
+
+// GetVersion -
+func (h *UnsafeVMHostMock) GetVersion() string {
+	return "unsafe mock"
+}
+
+// Crypto -
+func (h *UnsafeVMHostMock) Crypto() crypto.VMCrypto {
+	return nil
+}
+
+// Blockchain -
+func (h *UnsafeVMHostMock) Blockchain() vmhost.BlockchainContext {
+	return nil
+}
+
+// Runtime -
+func (h *UnsafeVMHostMock) Runtime() vmhost.RuntimeContext {
+	if h.runtimeContext == nil {
+		h.runtimeContext = &RuntimeContextMock{
+			VMHost: h,
+		}
+	}
+	return h.runtimeContext
+}
+
+// Output -
+func (h *UnsafeVMHostMock) Output() vmhost.OutputContext {
+	return nil
+}
+
+// Metering -
+func (h *UnsafeVMHostMock) Metering() vmhost.MeteringContext {
+	if h.meteringContext == nil {
+		h.meteringContext = &MeteringContextMock{}
+	}
+	return h.meteringContext
+}
+
+// Storage -
+func (h *UnsafeVMHostMock) Storage() vmhost.StorageContext {
+	return nil
+}
+
+// EnableEpochsHandler -
+func (h *UnsafeVMHostMock) EnableEpochsHandler() vmhost.EnableEpochsHandler {
+	return nil
+}
+
+// ManagedTypes -
+func (h *UnsafeVMHostMock) ManagedTypes() vmhost.ManagedTypesContext {
+	return nil
+}
+
+// AreInSameShard -
+func (h *UnsafeVMHostMock) AreInSameShard(left []byte, right []byte) bool {
+	return true
+}
+
+// IsAllowedToExecute -
+func (h *UnsafeVMHostMock) IsAllowedToExecute(_ string) bool {
+	return true
+}
+
+// ExecuteESDTTransfer -
+func (h *UnsafeVMHostMock) ExecuteESDTTransfer(_ *vmhost.ESDTTransfersArgs, _ vm.CallType) (*vmcommon.VMOutput, uint64, error) {
+	return nil, 0, nil
+}
+
+// CreateNewContract -
+func (h *UnsafeVMHostMock) CreateNewContract(_ *vmcommon.ContractCreateInput, _ int) ([]byte, error) {
+	return nil, nil
+}
+
+// ExecuteOnSameContext -
+func (h *UnsafeVMHostMock) ExecuteOnSameContext(_ *vmcommon.ContractCallInput) error {
+	return nil
+}
+
+// ExecuteOnDestContext -
+func (h *UnsafeVMHostMock) ExecuteOnDestContext(input *vmcommon.ContractCallInput) (*vmcommon.VMOutput, bool, error) {
+	return nil, true, nil
+}
+
+// InitState -
+func (h *UnsafeVMHostMock) InitState() {
+}
+
+// IsBuiltinFunctionName -
+func (h *UnsafeVMHostMock) IsBuiltinFunctionName(_ string) bool {
+	return false
+}
+
+// IsBuiltinFunctionCall -
+func (h *UnsafeVMHostMock) IsBuiltinFunctionCall(_ []byte) bool {
+	return false
+}
+
+// GetGasScheduleMap -
+func (h *UnsafeVMHostMock) GetGasScheduleMap() config.GasScheduleMap {
+	return make(config.GasScheduleMap)
+}
+
+// RunSmartContractCall -
+func (h *UnsafeVMHostMock) RunSmartContractCall(_ *vmcommon.ContractCallInput) (vmOutput *vmcommon.VMOutput, err error) {
+	return nil, nil
+}
+
+// RunSmartContractCreate -
+func (h *UnsafeVMHostMock) RunSmartContractCreate(_ *vmcommon.ContractCreateInput) (vmOutput *vmcommon.VMOutput, err error) {
+	return nil, nil
+}
+
+// GasScheduleChange -
+func (h *UnsafeVMHostMock) GasScheduleChange(_ config.GasScheduleMap) {
+}
+
+// SetBuiltInFunctionsContainer -
+func (h *UnsafeVMHostMock) SetBuiltInFunctionsContainer(_ vmcommon.BuiltInFunctionContainer) {
+}
+
+// IsInterfaceNil -
+func (h *UnsafeVMHostMock) IsInterfaceNil() bool {
+	return false
+}
+
+// GetContexts -
+func (h *UnsafeVMHostMock) GetContexts() (
+	vmhost.ManagedTypesContext,
+	vmhost.BlockchainContext,
+	vmhost.MeteringContext,
+	vmhost.OutputContext,
+	vmhost.RuntimeContext,
+	vmhost.AsyncContext,
+	vmhost.StorageContext,
+) {
+	return nil, nil, h.Metering(), nil, h.Runtime(), nil, nil
+}
+
+// SetRuntimeContext -
+func (h *UnsafeVMHostMock) SetRuntimeContext(runtime vmhost.RuntimeContext) {
+}
+
+// Async -
+func (h *UnsafeVMHostMock) Async() vmhost.AsyncContext {
+	return nil
+}
+
+// CompleteLogEntriesWithCallType -
+func (h *UnsafeVMHostMock) CompleteLogEntriesWithCallType(vmOutput *vmcommon.VMOutput, callType string) {
+}
+
+// Close -
+func (h *UnsafeVMHostMock) Close() error {
+	return nil
+}
+
+// Reset -
+func (h *UnsafeVMHostMock) Reset() {
+}
+
+// SetGasTracing -
+func (h *UnsafeVMHostMock) SetGasTracing(enableGasTracing bool) {
+}
+
+// GetGasTrace -
+func (h *UnsafeVMHostMock) GetGasTrace() map[string]map[string][]uint64 {
+	return make(map[string]map[string][]uint64)
+}
+
+// SetUnsafeMode sets the unsafe mode flag
+func (h *UnsafeVMHostMock) SetUnsafeMode(unsafeMode bool) {
+	h.unsafeMode = unsafeMode
+}
+
+// IsUnsafeMode returns true if the unsafe mode is enabled
+func (h *UnsafeVMHostMock) IsUnsafeMode() bool {
+	return h.unsafeMode
+}
+
+// FailExecution marks that FailExecution was called
+func (h *UnsafeVMHostMock) FailExecution(_ error) {
+	h.FailExecutionCalled = true
+	h.BreakpointValue = vmhost.BreakpointExecutionFailed
+}
+
+// FailExecutionConditionally marks that FailExecutionConditionally was called
+func (h *UnsafeVMHostMock) FailExecutionConditionally(err error) {
+	h.FailConditionallyCalled = true
+	if !h.unsafeMode {
+		h.FailExecution(err)
+	}
+}
+
+// RuntimeContextMock is a mock for the RuntimeContext interface
+type RuntimeContextMock struct {
+	vmhost.RuntimeContext
+	VMHost              vmhost.VMHost
+	FailExecutionCalled bool
+}
+
+// FailExecution -
+func (r *RuntimeContextMock) FailExecution(err error) {
+	r.VMHost.(*UnsafeVMHostMock).FailExecution(err)
+}
+
+// FailExecutionConditionally -
+func (r *RuntimeContextMock) FailExecutionConditionally(err error) {
+	r.VMHost.FailExecutionConditionally(err)
+}
+
+// MeteringContextMock is a mock for the MeteringContext interface
+type MeteringContextMock struct {
+	vmhost.MeteringContext
+	UseGasBoundedAndAddTracedGasCalled func(name string, gas uint64) error
+	UseGasBoundedCalled                func(gas uint64) error
+	GasLeftCalled                      func() uint64
+}
+
+// UseGasBoundedAndAddTracedGas -
+func (m *MeteringContextMock) UseGasBoundedAndAddTracedGas(name string, gas uint64) error {
+	if m.UseGasBoundedAndAddTracedGasCalled != nil {
+		return m.UseGasBoundedAndAddTracedGasCalled(name, gas)
+	}
+	return nil
+}
+
+// GasLeft -
+func (m *MeteringContextMock) GasLeft() uint64 {
+	if m.GasLeftCalled != nil {
+		return m.GasLeftCalled()
+	}
+	return 0
+}
+
+// UseGasBounded -
+func (m *MeteringContextMock) UseGasBounded(gas uint64) error {
+	if m.UseGasBoundedCalled != nil {
+		return m.UseGasBoundedCalled(gas)
+	}
+	return nil
+}

--- a/test/contracts/unsafeOps/multiversx.json
+++ b/test/contracts/unsafeOps/multiversx.json
@@ -1,0 +1,6 @@
+{
+    "language": "clang",
+    "source_files": [
+        "./unsafeOps.c"
+    ]
+}

--- a/test/contracts/unsafeOps/unsafeOps.c
+++ b/test/contracts/unsafeOps/unsafeOps.c
@@ -1,0 +1,24 @@
+#include "../mxvm/context.h"
+
+// Forward declaration of the C functions, assuming they are linked externally
+void mx_activate_unsafe_mode(void);
+void mx_deactivate_unsafe_mode(void);
+void bigIntTDiv(int, int, int);
+
+void activateUnsafeMode(void) {
+    mx_activate_unsafe_mode();
+}
+
+void deactivateUnsafeMode(void) {
+    mx_deactivate_unsafe_mode();
+}
+
+void testDivByZero(void) {
+    int a = bigIntNew(1);
+    int b = bigIntNew(0);
+    int c = bigIntNew(0);
+    bigIntTDiv(c, a, b);
+}
+
+// Dummy function to satisfy the build system
+void _start() {}

--- a/test/contracts/unsafeOps/unsafeOps.export
+++ b/test/contracts/unsafeOps/unsafeOps.export
@@ -1,0 +1,3 @@
+activateUnsafeMode
+deactivateUnsafeMode
+testDivByZero

--- a/vmhost/contexts/runtime.go
+++ b/vmhost/contexts/runtime.go
@@ -639,6 +639,19 @@ func (context *runtimeContext) FailExecution(err error) {
 	logRuntime.Trace("execution failed", "message", traceMessage)
 }
 
+// FailExecutionConditionally informs Wasmer to immediately stop the execution of the contract
+// with BreakpointExecutionFailed and sets the corresponding VMOutput fields accordingly, if the unsafe mode is not active.
+// If unsafe mode is active, it just logs the error.
+func (context *runtimeContext) FailExecutionConditionally(err error) {
+	if context.host.IsUnsafeMode() {
+		logRuntime.Debug("execution would have failed, but unsafe mode is active", "err", err)
+		context.AddError(err)
+		return
+	}
+
+	context.FailExecution(err)
+}
+
 // SignalUserError informs Wasmer to immediately stop the execution of the contract
 // with BreakpointSignalError and sets the corresponding VMOutput fields accordingly
 func (context *runtimeContext) SignalUserError(message string) {

--- a/vmhost/hostCore/host.go
+++ b/vmhost/hostCore/host.go
@@ -54,6 +54,7 @@ type vmHost struct {
 	mutExecution     sync.RWMutex
 	closingInstance  bool
 	executionTimeout time.Duration
+	unsafeMode       bool
 
 	ethInput []byte
 
@@ -324,6 +325,7 @@ func (host *vmHost) Reset() {
 }
 
 func (host *vmHost) initContexts() {
+	host.unsafeMode = false
 	host.ClearContextStateStack()
 	host.managedTypesContext.InitState()
 	host.outputContext.InitState()
@@ -562,6 +564,21 @@ func (host *vmHost) IsAllowedToExecute(opcode string) bool {
 // IsInterfaceNil returns true if there is no value under the interface
 func (host *vmHost) IsInterfaceNil() bool {
 	return host == nil
+}
+
+// SetUnsafeMode sets the unsafe mode flag
+func (host *vmHost) SetUnsafeMode(unsafeMode bool) {
+	host.unsafeMode = unsafeMode
+}
+
+// IsUnsafeMode returns true if the unsafe mode is enabled
+func (host *vmHost) IsUnsafeMode() bool {
+	return host.unsafeMode
+}
+
+// FailExecutionConditionally fails the execution with the provided error if the unsafe mode is not active
+func (host *vmHost) FailExecutionConditionally(err error) {
+	host.Runtime().FailExecutionConditionally(err)
 }
 
 // SetRuntimeContext sets the runtimeContext for this host, used in tests

--- a/vmhost/hostCore/unsafe_mode_test.go
+++ b/vmhost/hostCore/unsafe_mode_test.go
@@ -1,0 +1,35 @@
+package hostCore
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/multiversx/mx-chain-vm-go/mock/context"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsafeMode(t *testing.T) {
+	t.Run("safe mode", func(t *testing.T) {
+		host := &vmHost{}
+		runtimeContext := &context.RuntimeContextMock{}
+		host.runtimeContext = runtimeContext
+
+		host.SetUnsafeMode(false)
+
+		host.FailExecutionConditionally(errors.New("test error"))
+
+		assert.True(t, runtimeContext.FailExecutionCalled)
+	})
+
+	t.Run("unsafe mode", func(t *testing.T) {
+		host := &vmHost{}
+		runtimeContext := &context.RuntimeContextMock{}
+		host.runtimeContext = runtimeContext
+
+		host.SetUnsafeMode(true)
+
+		host.FailExecutionConditionally(errors.New("test error"))
+
+		assert.False(t, runtimeContext.FailExecutionCalled)
+	})
+}

--- a/vmhost/hosttest/unsafe_mode_test.go
+++ b/vmhost/hosttest/unsafe_mode_test.go
@@ -1,0 +1,80 @@
+package hostCoretest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/multiversx/mx-chain-vm-go/vmhost"
+	"github.com/stretchr/testify/assert"
+)
+
+type unsafeVMHostMock struct {
+	vmhost.VMHost
+	unsafeMode          bool
+	failExecutionCalled bool
+	breakpointValue     vmhost.BreakpointValue
+}
+
+func (h *unsafeVMHostMock) SetUnsafeMode(unsafeMode bool) {
+	h.unsafeMode = unsafeMode
+}
+
+func (h *unsafeVMHostMock) IsUnsafeMode() bool {
+	return h.unsafeMode
+}
+
+func (h *unsafeVMHostMock) FailExecution(err error) {
+	h.failExecutionCalled = true
+	h.breakpointValue = vmhost.BreakpointExecutionFailed
+}
+
+func (h *unsafeVMHostMock) FailExecutionConditionally(err error) {
+	if !h.unsafeMode {
+		h.FailExecution(err)
+	}
+}
+
+func (h *unsafeVMHostMock) Runtime() vmhost.RuntimeContext {
+	return &unsafeRuntimeContextMock{
+		VMHost: h,
+	}
+}
+
+type unsafeRuntimeContextMock struct {
+	vmhost.RuntimeContext
+	VMHost vmhost.VMHost
+}
+
+func (r *unsafeRuntimeContextMock) FailExecution(err error) {
+	r.VMHost.Runtime().FailExecution(err)
+}
+
+func (r *unsafeRuntimeContextMock) FailExecutionConditionally(err error) {
+	r.VMHost.Runtime().FailExecutionConditionally(err)
+}
+
+func (r *unsafeRuntimeContextMock) GetRuntimeBreakpointValue() vmhost.BreakpointValue {
+	return r.VMHost.(*unsafeVMHostMock).breakpointValue
+}
+
+func TestUnsafeMode(t *testing.T) {
+	t.Run("safe mode", func(t *testing.T) {
+		host := &unsafeVMHostMock{}
+		host.SetUnsafeMode(false)
+
+		host.FailExecutionConditionally(errors.New("test error"))
+
+		assert.True(t, host.failExecutionCalled)
+		assert.Equal(t, vmhost.BreakpointExecutionFailed, host.breakpointValue)
+	})
+
+	t.Run("unsafe mode", func(t *testing.T) {
+		host := &unsafeVMHostMock{}
+		host.SetUnsafeMode(true)
+
+		host.FailExecutionConditionally(errors.New("test error"))
+
+		assert.False(t, host.failExecutionCalled)
+		assert.Equal(t, vmhost.BreakpointNone, host.breakpointValue)
+	})
+}

--- a/vmhost/interface.go
+++ b/vmhost/interface.go
@@ -63,6 +63,9 @@ type VMHost interface {
 	Reset()
 	SetGasTracing(enableGasTracing bool)
 	GetGasTrace() map[string]map[string][]uint64
+	SetUnsafeMode(unsafeMode bool)
+	IsUnsafeMode() bool
+	FailExecutionConditionally(err error)
 }
 
 // BlockchainContext defines the functionality needed for interacting with the blockchain context
@@ -136,6 +139,7 @@ type RuntimeContext interface {
 	ExtractCodeUpgradeFromArgs() ([]byte, []byte, error)
 	SignalUserError(message string)
 	FailExecution(err error)
+	FailExecutionConditionally(err error)
 	MustVerifyNextContractCode()
 	SetRuntimeBreakpointValue(value BreakpointValue)
 	GetRuntimeBreakpointValue() BreakpointValue

--- a/vmhost/vmhooks/baseOps.go
+++ b/vmhost/vmhooks/baseOps.go
@@ -120,7 +120,7 @@ var logEEI = logger.GetOrCreate("vm/eei")
 func getESDTTransferFromInputFailIfWrongIndex(host vmhost.VMHost, index int32) *vmcommon.ESDTTransfer {
 	esdtTransfers := host.Runtime().GetVMInput().ESDTTransfers
 	if int32(len(esdtTransfers))-1 < index || index < 0 {
-		FailExecution(host, vmhost.ErrInvalidTokenIndex)
+		FailExecutionConditionally(host, vmhost.ErrInvalidTokenIndex)
 		return nil
 	}
 	return esdtTransfers[index]
@@ -129,7 +129,7 @@ func getESDTTransferFromInputFailIfWrongIndex(host vmhost.VMHost, index int32) *
 func failIfMoreThanOneESDTTransfer(context *VMHooksImpl) bool {
 	runtime := context.GetRuntimeContext()
 	if len(runtime.GetVMInput().ESDTTransfers) > 1 {
-		FailExecution(context.GetVMHost(), vmhost.ErrTooManyESDTTransfers)
+		FailExecutionConditionally(context.GetVMHost(), vmhost.ErrTooManyESDTTransfers)
 		return true
 	}
 	return false
@@ -398,7 +398,7 @@ func (context *VMHooksImpl) GetESDTNFTNameLength(
 		return -1
 	}
 	if esdtData == nil || esdtData.TokenMetaData == nil {
-		FailExecution(context.GetVMHost(), vmhost.ErrNilESDTData)
+		FailExecutionConditionally(context.GetVMHost(), vmhost.ErrNilESDTData)
 		return 0
 	}
 
@@ -423,7 +423,7 @@ func (context *VMHooksImpl) GetESDTNFTAttributeLength(
 		return -1
 	}
 	if esdtData == nil || esdtData.TokenMetaData == nil {
-		FailExecution(context.GetVMHost(), vmhost.ErrNilESDTData)
+		FailExecutionConditionally(context.GetVMHost(), vmhost.ErrNilESDTData)
 		return 0
 	}
 
@@ -448,7 +448,7 @@ func (context *VMHooksImpl) GetESDTNFTURILength(
 		return -1
 	}
 	if esdtData == nil || esdtData.TokenMetaData == nil {
-		FailExecution(context.GetVMHost(), vmhost.ErrNilESDTData)
+		FailExecutionConditionally(context.GetVMHost(), vmhost.ErrNilESDTData)
 		return 0
 	}
 	if len(esdtData.TokenMetaData.URIs) == 0 {
@@ -643,7 +643,7 @@ func (context *VMHooksImpl) TransferValue(
 	}
 
 	if host.IsBuiltinFunctionCall(data) {
-		context.FailExecution(vmhost.ErrTransferValueOnESDTCall)
+		context.FailExecutionConditionally(vmhost.ErrTransferValueOnESDTCall)
 		return 1
 	}
 
@@ -877,7 +877,7 @@ func TransferValueExecuteWithTypedArgs(
 
 	if contractCallInput != nil {
 		if host.IsBuiltinFunctionName(contractCallInput.Function) {
-			FailExecution(host, vmhost.ErrNilESDTData)
+			FailExecutionConditionally(host, vmhost.ErrNilESDTData)
 			return 1
 		}
 	}
@@ -890,7 +890,7 @@ func TransferValueExecuteWithTypedArgs(
 	lastRound := host.Blockchain().LastRound()
 	if host.IsBuiltinFunctionCall([]byte(data)) &&
 		lastRound >= uint64(host.EnableEpochsHandler().GetActivationEpoch(vmhost.CheckBuiltInCallOnTransferValueAndFailExecutionFlag)) {
-		FailExecution(host, vmhost.ErrTransferValueOnESDTCall)
+		FailExecutionConditionally(host, vmhost.ErrTransferValueOnESDTCall)
 		return 1
 	}
 
@@ -1003,7 +1003,7 @@ func (context *VMHooksImpl) MultiTransferESDTNFTExecute(
 	metering.StartGasTracing(multiTransferESDTNFTExecuteName)
 
 	if numTokenTransfers == 0 {
-		FailExecution(host, vmhost.ErrFailedTransfer)
+		FailExecutionConditionally(host, vmhost.ErrFailedTransfer)
 		return 1
 	}
 
@@ -1902,7 +1902,7 @@ func (context *VMHooksImpl) GetArgumentLength(id int32) int32 {
 
 	args := runtime.Arguments()
 	if id < 0 || int32(len(args)) <= id {
-		context.FailExecution(vmhost.ErrInvalidArgument)
+		context.FailExecutionConditionally(vmhost.ErrInvalidArgument)
 		return -1
 	}
 
@@ -1924,7 +1924,7 @@ func (context *VMHooksImpl) GetArgument(id int32, argOffset executor.MemPtr) int
 
 	args := runtime.Arguments()
 	if id < 0 || int32(len(args)) <= id {
-		context.FailExecution(vmhost.ErrInvalidArgument)
+		context.FailExecutionConditionally(vmhost.ErrInvalidArgument)
 		return -1
 	}
 
@@ -2350,11 +2350,11 @@ func (context *VMHooksImpl) CheckNoPayment() {
 
 	vmInput := runtime.GetVMInput()
 	if vmInput.CallValue.Sign() > 0 {
-		context.FailExecution(vmhost.ErrNonPayableFunctionEgld)
+		context.FailExecutionConditionally(vmhost.ErrNonPayableFunctionEgld)
 		return
 	}
 	if len(vmInput.ESDTTransfers) > 0 {
-		context.FailExecution(vmhost.ErrNonPayableFunctionEsdt)
+		context.FailExecutionConditionally(vmhost.ErrNonPayableFunctionEsdt)
 		return
 	}
 }
@@ -3159,7 +3159,7 @@ func ExecuteOnSameContextWithTypedArgs(
 	}
 
 	if host.IsBuiltinFunctionName(contractCallInput.Function) {
-		FailExecution(host, vmhost.ErrInvalidBuiltInFunctionCall)
+		FailExecutionConditionally(host, vmhost.ErrInvalidBuiltInFunctionCall)
 		return 1
 	}
 
@@ -3376,7 +3376,7 @@ func ExecuteReadOnlyWithTypedArguments(
 	}
 
 	if host.IsBuiltinFunctionName(contractCallInput.Function) {
-		FailExecution(host, vmhost.ErrInvalidBuiltInFunctionCall)
+		FailExecutionConditionally(host, vmhost.ErrInvalidBuiltInFunctionCall)
 		return 1
 	}
 
@@ -3670,7 +3670,7 @@ func (context *VMHooksImpl) GetReturnDataSize(resultID int32) int32 {
 
 	returnData := output.ReturnData()
 	if resultID >= int32(len(returnData)) || resultID < 0 {
-		context.FailExecution(vmhost.ErrInvalidArgument)
+		context.FailExecutionConditionally(vmhost.ErrInvalidArgument)
 		return 0
 	}
 
@@ -3709,7 +3709,7 @@ func GetReturnDataWithHostAndTypedArgs(host vmhost.VMHost, resultID int32) []byt
 
 	returnData := output.ReturnData()
 	if resultID >= int32(len(returnData)) || resultID < 0 {
-		FailExecution(host, vmhost.ErrInvalidArgument)
+		FailExecutionConditionally(host, vmhost.ErrInvalidArgument)
 		return nil
 	}
 

--- a/vmhost/vmhooks/bigFloatOps.go
+++ b/vmhost/vmhooks/bigFloatOps.go
@@ -45,13 +45,13 @@ func areAllZero(values ...*big.Float) bool {
 func setResultIfNotInfinity(host vmhost.VMHost, result *big.Float, destinationHandle int32) {
 	managedType := host.ManagedTypes()
 	if result.IsInf() {
-		FailExecution(host, vmhost.ErrInfinityFloatOperation)
+		FailExecutionConditionally(host, vmhost.ErrInfinityFloatOperation)
 		return
 	}
 
 	exponent := result.MantExp(nil)
 	if managedType.BigFloatExpIsNotValid(exponent) {
-		FailExecution(host, vmhost.ErrExponentTooBigOrTooSmall)
+		FailExecutionConditionally(host, vmhost.ErrExponentTooBigOrTooSmall)
 		return
 	}
 
@@ -78,7 +78,7 @@ func (context *VMHooksImpl) BigFloatNewFromParts(integralPart, fractionalPart, e
 	}
 
 	if exponent > 0 {
-		context.FailExecution(vmhost.ErrPositiveExponent)
+		context.FailExecutionConditionally(vmhost.ErrPositiveExponent)
 		return -1
 	}
 
@@ -131,7 +131,7 @@ func (context *VMHooksImpl) BigFloatNewFromFrac(numerator, denominator int64) in
 	}
 
 	if denominator == 0 {
-		context.FailExecution(vmhost.ErrDivZero)
+		context.FailExecutionConditionally(vmhost.ErrDivZero)
 		return -1
 	}
 
@@ -164,7 +164,7 @@ func (context *VMHooksImpl) BigFloatNewFromSci(significand, exponent int64) int3
 	}
 
 	if exponent > 0 {
-		context.FailExecution(vmhost.ErrPositiveExponent)
+		context.FailExecutionConditionally(vmhost.ErrPositiveExponent)
 		return -1
 	}
 	if exponent < -322 {
@@ -298,7 +298,7 @@ func (context *VMHooksImpl) BigFloatDiv(destinationHandle, op1Handle, op2Handle 
 		return
 	}
 	if areAllZero(op1, op2) {
-		context.FailExecution(vmhost.ErrAllOperandsAreEqualToZero)
+		context.FailExecutionConditionally(vmhost.ErrAllOperandsAreEqualToZero)
 		return
 	}
 
@@ -464,7 +464,7 @@ func (context *VMHooksImpl) BigFloatSqrt(destinationHandle, opHandle int32) {
 		return
 	}
 	if op.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBadLowerBounds)
+		context.FailExecutionConditionally(vmhost.ErrBadLowerBounds)
 		return
 	}
 	resultSqrt, err := vmMath.SqrtBigFloat(op)

--- a/vmhost/vmhooks/bigIntOps.go
+++ b/vmhost/vmhooks/bigIntOps.go
@@ -524,7 +524,7 @@ func (context *VMHooksImpl) BigIntGetInt64(destinationHandle int32) int64 {
 
 	value := managedType.GetBigIntOrCreate(destinationHandle)
 	if !value.IsInt64() {
-		context.FailExecution(vmhost.ErrBigIntCannotBeRepresentedAsInt64)
+		context.FailExecutionConditionally(vmhost.ErrBigIntCannotBeRepresentedAsInt64)
 		return -1
 	}
 	return value.Int64()
@@ -665,7 +665,7 @@ func (context *VMHooksImpl) BigIntTDiv(destinationHandle, op1Handle, op2Handle i
 	}
 
 	if b.Sign() == 0 {
-		context.FailExecution(vmhost.ErrDivZero)
+		context.FailExecutionConditionally(vmhost.ErrDivZero)
 		return
 	}
 	dest.Quo(a, b) // Quo implements truncated division (like Go)
@@ -699,7 +699,7 @@ func (context *VMHooksImpl) BigIntTMod(destinationHandle, op1Handle, op2Handle i
 	}
 
 	if b.Sign() == 0 {
-		context.FailExecution(vmhost.ErrDivZero)
+		context.FailExecutionConditionally(vmhost.ErrDivZero)
 		return
 	}
 	dest.Rem(a, b) // Rem implements truncated modulus (like Go)
@@ -733,7 +733,7 @@ func (context *VMHooksImpl) BigIntEDiv(destinationHandle, op1Handle, op2Handle i
 	}
 
 	if b.Sign() == 0 {
-		context.FailExecution(vmhost.ErrDivZero)
+		context.FailExecutionConditionally(vmhost.ErrDivZero)
 		return
 	}
 	dest.Div(a, b) // Div implements Euclidean division (unlike Go)
@@ -767,7 +767,7 @@ func (context *VMHooksImpl) BigIntEMod(destinationHandle, op1Handle, op2Handle i
 	}
 
 	if b.Sign() == 0 {
-		context.FailExecution(vmhost.ErrDivZero)
+		context.FailExecutionConditionally(vmhost.ErrDivZero)
 		return
 	}
 	dest.Mod(a, b) // Mod implements Euclidean division (unlike Go)
@@ -801,7 +801,7 @@ func (context *VMHooksImpl) BigIntSqrt(destinationHandle, opHandle int32) {
 	}
 
 	if a.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBadLowerBounds)
+		context.FailExecutionConditionally(vmhost.ErrBadLowerBounds)
 		return
 	}
 	dest.Sqrt(a)
@@ -844,7 +844,7 @@ func (context *VMHooksImpl) BigIntPow(destinationHandle, op1Handle, op2Handle in
 	}
 
 	if b.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBadLowerBounds)
+		context.FailExecutionConditionally(vmhost.ErrBadLowerBounds)
 		return
 	}
 
@@ -878,7 +878,7 @@ func (context *VMHooksImpl) BigIntLog2(op1Handle int32) int32 {
 	}
 
 	if a.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBadLowerBounds)
+		context.FailExecutionConditionally(vmhost.ErrBadLowerBounds)
 		return -1
 	}
 
@@ -1031,7 +1031,7 @@ func (context *VMHooksImpl) BigIntNot(destinationHandle, opHandle int32) {
 	}
 
 	if a.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBitwiseNegative)
+		context.FailExecutionConditionally(vmhost.ErrBitwiseNegative)
 		return
 	}
 	dest.Not(a)
@@ -1065,7 +1065,7 @@ func (context *VMHooksImpl) BigIntAnd(destinationHandle, op1Handle, op2Handle in
 	}
 
 	if a.Sign() < 0 || b.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBitwiseNegative)
+		context.FailExecutionConditionally(vmhost.ErrBitwiseNegative)
 		return
 	}
 	dest.And(a, b)
@@ -1099,7 +1099,7 @@ func (context *VMHooksImpl) BigIntOr(destinationHandle, op1Handle, op2Handle int
 	}
 
 	if a.Sign() < 0 || b.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBitwiseNegative)
+		context.FailExecutionConditionally(vmhost.ErrBitwiseNegative)
 		return
 	}
 	dest.Or(a, b)
@@ -1133,7 +1133,7 @@ func (context *VMHooksImpl) BigIntXor(destinationHandle, op1Handle, op2Handle in
 	}
 
 	if a.Sign() < 0 || b.Sign() < 0 {
-		context.FailExecution(vmhost.ErrBitwiseNegative)
+		context.FailExecutionConditionally(vmhost.ErrBitwiseNegative)
 		return
 	}
 	dest.Xor(a, b)
@@ -1167,7 +1167,7 @@ func (context *VMHooksImpl) BigIntShr(destinationHandle, opHandle, bits int32) {
 	}
 
 	if a.Sign() < 0 || bits < 0 {
-		context.FailExecution(vmhost.ErrShiftNegative)
+		context.FailExecutionConditionally(vmhost.ErrShiftNegative)
 		return
 	}
 	dest.Rsh(a, uint(bits))
@@ -1208,7 +1208,7 @@ func (context *VMHooksImpl) BigIntShl(destinationHandle, opHandle, bits int32) {
 	}
 
 	if a.Sign() < 0 || bits < 0 {
-		context.FailExecution(vmhost.ErrShiftNegative)
+		context.FailExecutionConditionally(vmhost.ErrShiftNegative)
 		return
 	}
 

--- a/vmhost/vmhooks/cryptoei.go
+++ b/vmhost/vmhooks/cryptoei.go
@@ -349,7 +349,7 @@ func (context *VMHooksImpl) VerifyBLS(
 			invalidSigErr = vmhost.ErrBlsVerify
 		}
 
-		context.FailExecution(invalidSigErr)
+		context.FailExecutionConditionally(invalidSigErr)
 		return -1
 	}
 
@@ -466,7 +466,7 @@ func ManagedVerifyBLSWithHost(
 			invalidSigErr = vmhost.ErrBlsVerify
 		}
 
-		FailExecution(host, invalidSigErr)
+		FailExecutionConditionally(host, invalidSigErr)
 		return -1
 	}
 
@@ -524,7 +524,7 @@ func (context *VMHooksImpl) VerifyEd25519(
 			invalidSigErr = vmhost.ErrEd25519Verify
 		}
 
-		context.FailExecution(invalidSigErr)
+		context.FailExecutionConditionally(invalidSigErr)
 		return -1
 	}
 
@@ -600,7 +600,7 @@ func ManagedVerifyEd25519WithHost(
 			invalidSigErr = vmhost.ErrEd25519Verify
 		}
 
-		FailExecution(host, invalidSigErr)
+		FailExecutionConditionally(host, invalidSigErr)
 		return -1
 	}
 
@@ -675,7 +675,7 @@ func (context *VMHooksImpl) VerifyCustomSecp256k1(
 			invalidSigErr = vmhost.ErrSecp256k1Verify
 		}
 
-		context.FailExecution(invalidSigErr)
+		context.FailExecutionConditionally(invalidSigErr)
 		return -1
 	}
 
@@ -766,7 +766,7 @@ func ManagedVerifyCustomSecp256k1WithHost(
 			invalidSigErr = vmhost.ErrSecp256k1Verify
 		}
 
-		FailExecution(host, invalidSigErr)
+		FailExecutionConditionally(host, invalidSigErr)
 		return -1
 	}
 
@@ -949,7 +949,7 @@ func (context *VMHooksImpl) AddEC(
 	}
 
 	if !ec.IsOnCurve(x1, y1) || !ec.IsOnCurve(x2, y2) {
-		context.FailExecution(vmhost.ErrPointNotOnCurve)
+		context.FailExecutionConditionally(vmhost.ErrPointNotOnCurve)
 		return
 	}
 
@@ -1001,7 +1001,7 @@ func (context *VMHooksImpl) DoubleEC(
 		return
 	}
 	if !ec.IsOnCurve(x, y) {
-		context.FailExecution(vmhost.ErrPointNotOnCurve)
+		context.FailExecutionConditionally(vmhost.ErrPointNotOnCurve)
 		return
 	}
 
@@ -1187,7 +1187,7 @@ func commonScalarBaseMultEC(
 
 	xResultSBM, yResultSBM := ec.ScalarBaseMult(data)
 	if !ec.IsOnCurve(xResultSBM, yResultSBM) {
-		FailExecution(host, vmhost.ErrPointNotOnCurve)
+		FailExecutionConditionally(host, vmhost.ErrPointNotOnCurve)
 		return 1
 	}
 	xResult.Set(xResultSBM)
@@ -1324,7 +1324,7 @@ func commonScalarMultEC(
 		return 1
 	}
 	if !ec.IsOnCurve(x, y) {
-		FailExecution(host, vmhost.ErrPointNotOnCurve)
+		FailExecutionConditionally(host, vmhost.ErrPointNotOnCurve)
 		return 1
 	}
 
@@ -1336,7 +1336,7 @@ func commonScalarMultEC(
 
 	xResultSM, yResultSM := ec.ScalarMult(x, y, data)
 	if !ec.IsOnCurve(xResultSM, yResultSM) {
-		FailExecution(host, vmhost.ErrPointNotOnCurve)
+		FailExecutionConditionally(host, vmhost.ErrPointNotOnCurve)
 		return 1
 	}
 	xResult.Set(xResultSM)
@@ -1673,7 +1673,7 @@ func commonUnmarshalEC(
 
 	xResultU, yResultU := elliptic.Unmarshal(ec, data)
 	if xResultU == nil || yResultU == nil || !ec.IsOnCurve(xResultU, yResultU) {
-		FailExecution(host, vmhost.ErrPointNotOnCurve)
+		FailExecutionConditionally(host, vmhost.ErrPointNotOnCurve)
 		return 1
 	}
 	xResult.Set(xResultU)
@@ -1802,7 +1802,7 @@ func commonUnmarshalCompressedEC(
 
 	xResultUC, yResultUC := elliptic.UnmarshalCompressed(ec, data)
 	if xResultUC == nil || yResultUC == nil || !ec.IsOnCurve(xResultUC, yResultUC) {
-		FailExecution(host, vmhost.ErrPointNotOnCurve)
+		FailExecutionConditionally(host, vmhost.ErrPointNotOnCurve)
 		return 1
 	}
 	xResult.Set(xResultUC)

--- a/vmhost/vmhooks/generate/cmd/eiGenMain.go
+++ b/vmhost/vmhooks/generate/cmd/eiGenMain.go
@@ -27,6 +27,7 @@ func initEIMetadata() *eapigen.EIMetadata {
 			{SourcePath: "manMapOps.go", Name: "ManagedMap"},
 			{SourcePath: "smallIntOps.go", Name: "SmallInt"},
 			{SourcePath: "cryptoei.go", Name: "Crypto"},
+			{SourcePath: "unsafeOps.go", Name: "Unsafe"},
 		},
 		AllFunctions: nil,
 	}

--- a/vmhost/vmhooks/manBufOps.go
+++ b/vmhost/vmhooks/manBufOps.go
@@ -92,7 +92,7 @@ func (context *VMHooksImpl) MBufferGetLength(mBufferHandle int32) int32 {
 
 	length := managedType.GetLength(mBufferHandle)
 	if length == -1 {
-		context.FailExecution(vmhost.ErrNoManagedBufferUnderThisHandle)
+		context.FailExecutionConditionally(vmhost.ErrNoManagedBufferUnderThisHandle)
 		return -1
 	}
 
@@ -402,7 +402,7 @@ func (context *VMHooksImpl) MBufferAppend(accumulatorHandle int32, dataHandle in
 
 	isSuccess := managedType.AppendBytes(accumulatorHandle, dataBufferBytes)
 	if !isSuccess {
-		context.FailExecution(vmhost.ErrNoManagedBufferUnderThisHandle)
+		context.FailExecutionConditionally(vmhost.ErrNoManagedBufferUnderThisHandle)
 		return 1
 	}
 
@@ -431,7 +431,7 @@ func (context *VMHooksImpl) MBufferAppendBytes(accumulatorHandle int32, dataOffs
 
 	isSuccess := managedType.AppendBytes(accumulatorHandle, data)
 	if !isSuccess {
-		context.FailExecution(vmhost.ErrNoManagedBufferUnderThisHandle)
+		context.FailExecutionConditionally(vmhost.ErrNoManagedBufferUnderThisHandle)
 		return 1
 	}
 
@@ -590,7 +590,7 @@ func (context *VMHooksImpl) MBufferToSmallIntUnsigned(mBufferHandle int32) int64
 
 	bigInt := big.NewInt(0).SetBytes(data)
 	if !bigInt.IsUint64() {
-		context.FailExecution(vmhost.ErrBytesExceedUint64)
+		context.FailExecutionConditionally(vmhost.ErrBytesExceedUint64)
 		return 0
 	}
 	return int64(bigInt.Uint64())
@@ -624,7 +624,7 @@ func (context *VMHooksImpl) MBufferToSmallIntSigned(mBufferHandle int32) int64 {
 
 	bigInt := twos.SetBytes(big.NewInt(0), data)
 	if !bigInt.IsInt64() {
-		context.FailExecution(vmhost.ErrBytesExceedInt64)
+		context.FailExecutionConditionally(vmhost.ErrBytesExceedInt64)
 		return 0
 	}
 	return bigInt.Int64()
@@ -692,7 +692,7 @@ func (context *VMHooksImpl) MBufferToBigFloat(mBufferHandle, bigFloatHandle int3
 	}
 
 	if managedType.EncodedBigFloatIsNotValid(managedBuffer) {
-		context.FailExecution(vmhost.ErrBigFloatWrongPrecision)
+		context.FailExecutionConditionally(vmhost.ErrBigFloatWrongPrecision)
 		return 1
 	}
 
@@ -719,7 +719,7 @@ func (context *VMHooksImpl) MBufferToBigFloat(mBufferHandle, bigFloatHandle int3
 	}
 
 	if bigFloat.IsInf() {
-		context.FailExecution(vmhost.ErrInfinityFloatOperation)
+		context.FailExecutionConditionally(vmhost.ErrInfinityFloatOperation)
 		return 1
 	}
 
@@ -900,7 +900,7 @@ func (context *VMHooksImpl) MBufferGetArgument(id int32, destinationHandle int32
 
 	args := runtime.Arguments()
 	if int32(len(args)) <= id || id < 0 {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return 1
 	}
 	managedType.SetBytes(destinationHandle, args[id])
@@ -946,7 +946,7 @@ func (context *VMHooksImpl) MBufferSetRandom(destinationHandle int32, length int
 	metering := context.GetMeteringContext()
 
 	if length < 1 {
-		context.FailExecution(vmhost.ErrLengthOfBufferNotCorrect)
+		context.FailExecutionConditionally(vmhost.ErrLengthOfBufferNotCorrect)
 		return -1
 	}
 

--- a/vmhost/vmhooks/managedei.go
+++ b/vmhost/vmhooks/managedei.go
@@ -321,7 +321,7 @@ func (context *VMHooksImpl) ManagedGetReturnData(resultID int32, resultHandle in
 
 	returnData := output.ReturnData()
 	if resultID >= int32(len(returnData)) || resultID < 0 {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return
 	}
 
@@ -448,18 +448,18 @@ func (context *VMHooksImpl) ManagedGetESDTBalance(addressHandle int32, tokenIDHa
 
 	address, err := managedType.GetBytes(addressHandle)
 	if err != nil {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return
 	}
 	tokenID, err := managedType.GetBytes(tokenIDHandle)
 	if err != nil {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return
 	}
 
 	esdtToken, err := blockchain.GetESDTToken(address, tokenID, uint64(nonce))
 	if err != nil {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return
 	}
 
@@ -504,18 +504,18 @@ func ManagedGetESDTTokenDataWithHost(
 
 	address, err := managedType.GetBytes(addressHandle)
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 	tokenID, err := managedType.GetBytes(tokenIDHandle)
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 
 	esdtToken, err := blockchain.GetESDTToken(address, tokenID, uint64(nonce))
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 
@@ -597,18 +597,18 @@ func ManagedGetESDTTokenTypeWithHost(
 
 	address, err := managedType.GetBytes(addressHandle)
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 	tokenID, err := managedType.GetBytes(tokenIDHandle)
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 
 	esdtToken, err := blockchain.GetESDTToken(address, tokenID, uint64(nonce))
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 
@@ -662,7 +662,7 @@ func ManagedAsyncCallWithHost(
 
 	value, err := managedType.GetBigInt(valueHandle)
 	if err != nil {
-		FailExecution(host, vmhost.ErrArgOutOfRange)
+		FailExecutionConditionally(host, vmhost.ErrArgOutOfRange)
 		return
 	}
 
@@ -713,7 +713,7 @@ func (context *VMHooksImpl) ManagedCreateAsyncCall(
 
 	value, err := managedType.GetBigInt(valueHandle)
 	if err != nil {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return 1
 	}
 
@@ -1359,7 +1359,7 @@ func (context *VMHooksImpl) ManagedMultiTransferESDTNFTExecuteByUser(
 	metering.StartGasTracing(managedMultiTransferESDTNFTExecuteByUser)
 
 	if !host.IsAllowedToExecute(managedMultiTransferESDTNFTExecuteByUser) {
-		FailExecution(host, vmhost.ErrOpcodeIsNotAllowed)
+		FailExecutionConditionally(host, vmhost.ErrOpcodeIsNotAllowed)
 		return -1
 	}
 

--- a/vmhost/vmhooks/smallIntOps.go
+++ b/vmhost/vmhooks/smallIntOps.go
@@ -38,14 +38,14 @@ func (context *VMHooksImpl) SmallIntGetUnsignedArgument(id int32) int64 {
 
 	args := runtime.Arguments()
 	if id < 0 || id >= int32(len(args)) {
-		context.FailExecution(vmhost.ErrArgIndexOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgIndexOutOfRange)
 		return 0
 	}
 
 	arg := args[id]
 	argBigInt := big.NewInt(0).SetBytes(arg)
 	if !argBigInt.IsUint64() {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return 0
 	}
 	return int64(argBigInt.Uint64())
@@ -66,14 +66,14 @@ func (context *VMHooksImpl) SmallIntGetSignedArgument(id int32) int64 {
 
 	args := runtime.Arguments()
 	if id < 0 || id >= int32(len(args)) {
-		context.FailExecution(vmhost.ErrArgIndexOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgIndexOutOfRange)
 		return 0
 	}
 
 	arg := args[id]
 	argBigInt := twos.SetBytes(big.NewInt(0), arg)
 	if !argBigInt.IsInt64() {
-		context.FailExecution(vmhost.ErrArgOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrArgOutOfRange)
 		return 0
 	}
 	return argBigInt.Int64()
@@ -201,7 +201,7 @@ func (context *VMHooksImpl) SmallIntStorageLoadUnsigned(keyOffset executor.MemPt
 
 	valueBigInt := big.NewInt(0).SetBytes(data)
 	if !valueBigInt.IsUint64() {
-		context.FailExecution(vmhost.ErrStorageValueOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrStorageValueOutOfRange)
 		return 0
 	}
 
@@ -238,7 +238,7 @@ func (context *VMHooksImpl) SmallIntStorageLoadSigned(keyOffset executor.MemPtr,
 
 	valueBigInt := twos.SetBytes(big.NewInt(0), data)
 	if !valueBigInt.IsInt64() {
-		context.FailExecution(vmhost.ErrStorageValueOutOfRange)
+		context.FailExecutionConditionally(vmhost.ErrStorageValueOutOfRange)
 		return 0
 	}
 

--- a/vmhost/vmhooks/unsafeOps.go
+++ b/vmhost/vmhooks/unsafeOps.go
@@ -1,0 +1,32 @@
+package vmhooks
+
+const (
+	activateUnsafeModeName   = "activateUnsafeMode"
+	deactivateUnsafeModeName = "deactivateUnsafeMode"
+)
+
+// ActivateUnsafeMode VMHooks implementation.
+// @autogenerate(VMHooks)
+func (context *VMHooksImpl) ActivateUnsafeMode() {
+	metering := context.GetMeteringContext()
+	err := metering.UseGasBoundedAndAddTracedGas(activateUnsafeModeName, 1)
+	if err != nil {
+		context.FailExecution(err)
+		return
+	}
+
+	context.host.SetUnsafeMode(true)
+}
+
+// DeactivateUnsafeMode VMHooks implementation.
+// @autogenerate(VMHooks)
+func (context *VMHooksImpl) DeactivateUnsafeMode() {
+	metering := context.GetMeteringContext()
+	err := metering.UseGasBoundedAndAddTracedGas(deactivateUnsafeModeName, 1)
+	if err != nil {
+		context.FailExecution(err)
+		return
+	}
+
+	context.host.SetUnsafeMode(false)
+}

--- a/vmhost/vmhooks/unsafeOps_test.go
+++ b/vmhost/vmhooks/unsafeOps_test.go
@@ -1,0 +1,68 @@
+package vmhooks
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/multiversx/mx-chain-vm-go/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnsafeOps_ActivateUnsafeMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should set unsafe mode to true", func(t *testing.T) {
+		t.Parallel()
+
+		host := &mock.UnsafeVMHostMock{}
+		hooks := NewVMHooksImpl(host)
+
+		hooks.ActivateUnsafeMode()
+
+		assert.True(t, host.IsUnsafeMode())
+	})
+
+	t.Run("should fail when out of gas", func(t *testing.T) {
+		t.Parallel()
+
+		host := &mock.UnsafeVMHostMock{}
+		host.Metering().(*mock.MeteringContextMock).UseGasBoundedAndAddTracedGasCalled = func(name string, gas uint64) error {
+			return errors.New("out of gas")
+		}
+		hooks := NewVMHooksImpl(host)
+
+		hooks.ActivateUnsafeMode()
+
+		assert.True(t, host.FailExecutionCalled)
+	})
+}
+
+func TestUnsafeOps_DeactivateUnsafeMode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("should set unsafe mode to false", func(t *testing.T) {
+		t.Parallel()
+
+		host := &mock.UnsafeVMHostMock{}
+		host.SetUnsafeMode(true)
+		hooks := NewVMHooksImpl(host)
+
+		hooks.DeactivateUnsafeMode()
+
+		assert.False(t, host.IsUnsafeMode())
+	})
+
+	t.Run("should fail when out of gas", func(t *testing.T) {
+		t.Parallel()
+
+		host := &mock.UnsafeVMHostMock{}
+		host.Metering().(*mock.MeteringContextMock).UseGasBoundedAndAddTracedGasCalled = func(name string, gas uint64) error {
+			return errors.New("out of gas")
+		}
+		hooks := NewVMHooksImpl(host)
+
+		hooks.DeactivateUnsafeMode()
+
+		assert.True(t, host.FailExecutionCalled)
+	})
+}

--- a/vmhost/vmhooks/vmHooksImpl.go
+++ b/vmhost/vmhooks/vmHooksImpl.go
@@ -97,6 +97,11 @@ func (context *VMHooksImpl) FailExecution(err error) {
 	FailExecution(context.host, err)
 }
 
+// FailExecutionConditionally fails the execution with the provided error if the unsafe mode is not active
+func (context *VMHooksImpl) FailExecutionConditionally(err error) {
+	FailExecutionConditionally(context.host, err)
+}
+
 // GetEnableEpochsHandler returns the enable epochs handler
 func (context *VMHooksImpl) GetEnableEpochsHandler() vmhost.EnableEpochsHandler {
 	return context.host.EnableEpochsHandler()
@@ -112,4 +117,14 @@ func FailExecution(host vmhost.VMHost, err error) {
 	metering := host.Metering()
 	_ = metering.UseGasBounded(metering.GasLeft())
 	runtime.FailExecution(err)
+}
+
+// FailExecutionConditionally fails the execution with the provided error if the unsafe mode is not active
+func FailExecutionConditionally(host vmhost.VMHost, err error) {
+	if err == nil {
+		return
+	}
+
+	runtime := host.Runtime()
+	runtime.FailExecutionConditionally(err)
 }

--- a/wasmer2/libvmexeccapi.h
+++ b/wasmer2/libvmexeccapi.h
@@ -315,6 +315,8 @@ typedef struct {
   int32_t (*managed_verify_secp256r1_func_ptr)(void *context, int32_t key_handle, int32_t message_handle, int32_t sig_handle);
   int32_t (*managed_verify_blssignature_share_func_ptr)(void *context, int32_t key_handle, int32_t message_handle, int32_t sig_handle);
   int32_t (*managed_verify_blsaggregated_signature_func_ptr)(void *context, int32_t key_handle, int32_t message_handle, int32_t sig_handle);
+  void (*activate_unsafe_mode_func_ptr)(void *context);
+  void (*deactivate_unsafe_mode_func_ptr)(void *context);
 } vm_exec_vm_hook_c_func_pointers;
 
 typedef struct {

--- a/wasmer2/wasmer2ImportsCgo.go
+++ b/wasmer2/wasmer2ImportsCgo.go
@@ -288,6 +288,8 @@ package wasmer2
 // extern int32_t   w2_managedVerifySecp256r1(void* context, int32_t keyHandle, int32_t messageHandle, int32_t sigHandle);
 // extern int32_t   w2_managedVerifyBLSSignatureShare(void* context, int32_t keyHandle, int32_t messageHandle, int32_t sigHandle);
 // extern int32_t   w2_managedVerifyBLSAggregatedSignature(void* context, int32_t keyHandle, int32_t messageHandle, int32_t sigHandle);
+// extern void      w2_activateUnsafeMode(void* context);
+// extern void      w2_deactivateUnsafeMode(void* context);
 import "C"
 
 import (
@@ -576,6 +578,8 @@ func populateCgoFunctionPointers() *cWasmerVmHookPointers {
 		managed_verify_secp256r1_func_ptr:                            funcPointer(C.w2_managedVerifySecp256r1),
 		managed_verify_blssignature_share_func_ptr:                   funcPointer(C.w2_managedVerifyBLSSignatureShare),
 		managed_verify_blsaggregated_signature_func_ptr:              funcPointer(C.w2_managedVerifyBLSAggregatedSignature),
+		activate_unsafe_mode_func_ptr:                                funcPointer(C.w2_activateUnsafeMode),
+		deactivate_unsafe_mode_func_ptr:                              funcPointer(C.w2_deactivateUnsafeMode),
 	}
 }
 
@@ -2239,4 +2243,16 @@ func w2_managedVerifyBLSSignatureShare(context unsafe.Pointer, keyHandle int32, 
 func w2_managedVerifyBLSAggregatedSignature(context unsafe.Pointer, keyHandle int32, messageHandle int32, sigHandle int32) int32 {
 	vmHooks := getVMHooksFromContextRawPtr(context)
 	return vmHooks.ManagedVerifyBLSAggregatedSignature(keyHandle, messageHandle, sigHandle)
+}
+
+//export w2_activateUnsafeMode
+func w2_activateUnsafeMode(context unsafe.Pointer) {
+	vmHooks := getVMHooksFromContextRawPtr(context)
+	vmHooks.ActivateUnsafeMode()
+}
+
+//export w2_deactivateUnsafeMode
+func w2_deactivateUnsafeMode(context unsafe.Pointer) {
+	vmHooks := getVMHooksFromContextRawPtr(context)
+	vmHooks.DeactivateUnsafeMode()
 }

--- a/wasmer2/wasmer2Names.go
+++ b/wasmer2/wasmer2Names.go
@@ -286,4 +286,6 @@ var functionNames = map[string]struct{}{
 	"managedVerifySecp256r1":                       empty,
 	"managedVerifyBLSSignatureShare":               empty,
 	"managedVerifyBLSAggregatedSignature":          empty,
+	"activateUnsafeMode":                           empty,
+	"deactivateUnsafeMode":                         empty,
 }


### PR DESCRIPTION
I've introduced an unsafe execution mode for smart contracts. When activated, certain errors that would normally halt the execution of a smart contract will be ignored. This allows you to build more resilient contracts that can handle unexpected errors without crashing.

The following changes were made:

- I added `activateUnsafeMode` and `deactivateUnsafeMode` hooks to allow smart contracts to control the unsafe mode.
- I added a `FailExecutionConditionally` function that only fails the execution if the unsafe mode is not active.
- I replaced `FailExecution` with `FailExecutionConditionally` in various hooks where it makes sense to allow for non-fatal errors.
- I added mock tests to verify the new functionality.