### PR TITLE
feat: Add error tests for zkcrypto-ei

### DIFF
--- a/vmhost/vmhooks/ec_generated_test.go
+++ b/vmhost/vmhooks/ec_generated_test.go
@@ -1,0 +1,320 @@
+package vmhooks
+
+import (
+	"testing"
+
+	"github.com/multiversx/mx-chain-crypto-go/zk/lowLevelFeatures"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestManagedAddEC_Fail_GetPoint1Bytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return(nil, assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedAddEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedPairingChecksEC_Fail_ReadVectors(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return(nil, uint64(0), assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedPairingChecksEC(int32(lowLevelFeatures.BN254), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedPairingChecksEC_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return([][]byte{}, uint64(0), nil)
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(2)).Return([][]byte{}, uint64(0), nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedPairingChecksEC(int32(42), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedPairingChecksEC_Fail_PairingCheck(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return([][]byte{[]byte("dummy point")}, uint64(1), nil)
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(2)).Return([][]byte{[]byte("dummy point")}, uint64(1), nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedPairingChecksEC(int32(lowLevelFeatures.BN254), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMultiExpEC_Fail_ReadVectors(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return(nil, uint64(0), assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMultiExpEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMultiExpEC_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return([][]byte{}, uint64(0), nil)
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(2)).Return([][]byte{}, uint64(0), nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMultiExpEC(int32(42), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMultiExpEC_Fail_InvalidGroup(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return([][]byte{}, uint64(0), nil)
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(2)).Return([][]byte{}, uint64(0), nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMultiExpEC(int32(lowLevelFeatures.BN254), int32(42), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMultiExpEC_Fail_MultiExp(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(1)).Return([][]byte{[]byte("dummy point")}, uint64(1), nil)
+	managedType.On("ReadManagedVecOfManagedBuffers", int32(2)).Return([][]byte{[]byte("dummy scalar")}, uint64(1), nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMultiExpEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMapToCurveEC_Fail_GetElementBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return(nil, assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMapToCurveEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMapToCurveEC_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy element"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMapToCurveEC(int32(42), int32(lowLevelFeatures.G1), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMapToCurveEC_Fail_InvalidGroup(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy element"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMapToCurveEC(int32(lowLevelFeatures.BN254), int32(42), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMapToCurveEC_Fail_Map(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy element"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMapToCurveEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMulEC_Fail_GetPointBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return(nil, assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMulEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMulEC_Fail_GetScalarBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point"), nil)
+	managedType.On("GetBytes", int32(2)).Return(nil, assert.AnError)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMulEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMulEC_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy scalar"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMulEC(int32(42), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMulEC_Fail_InvalidGroup(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy scalar"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMulEC(int32(lowLevelFeatures.BN254), int32(42), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedMulEC_Fail_Mul(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy scalar"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedMulEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedAddEC_Fail_GetPoint2Bytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point"), nil)
+	managedType.On("GetBytes", int32(2)).Return(nil, assert.AnError)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedAddEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedAddEC_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point 1"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy point 2"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedAddEC(int32(42), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedAddEC_Fail_InvalidGroup(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point 1"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy point 2"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedAddEC(int32(lowLevelFeatures.BN254), int32(42), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedAddEC_Fail_Add(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy point 1"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy point 2"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedAddEC(int32(lowLevelFeatures.BN254), int32(lowLevelFeatures.G1), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}

--- a/vmhost/vmhooks/zkcryptoei.go
+++ b/vmhost/vmhooks/zkcryptoei.go
@@ -22,7 +22,7 @@ const (
 // @autogenerate(VMHooks)
 func (context *VMHooksImpl) ManagedVerifyGroth16(
 	curveID int32, proofHandle, vkHandle, pubWitnessHandle int32,
-) int32 {
+) (ret int32) {
 	host := context.GetVMHost()
 	return ManagedVerifyZKFunctionWithHost(
 		host, managedVerifyGroth16, curveID, proofHandle, vkHandle, pubWitnessHandle)
@@ -32,7 +32,7 @@ func (context *VMHooksImpl) ManagedVerifyGroth16(
 // @autogenerate(VMHooks)
 func (context *VMHooksImpl) ManagedVerifyPlonk(
 	curveID int32, proofHandle, vkHandle, pubWitnessHandle int32,
-) int32 {
+) (ret int32) {
 	host := context.GetVMHost()
 	return ManagedVerifyZKFunctionWithHost(
 		host, managedVerifyPlonk, curveID, proofHandle, vkHandle, pubWitnessHandle)
@@ -58,7 +58,14 @@ func ManagedVerifyZKFunctionWithHost(
 	zkFunc string,
 	curveID int32,
 	proofHandle, vkHandle, pubWitnessHandle int32,
-) int32 {
+) (ret int32) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = -1
+			FailExecutionConditionally(host, vmhost.ErrExecutionPanicked)
+		}
+	}()
+
 	metering := host.Metering()
 	managedType := host.ManagedTypes()
 

--- a/vmhost/vmhooks/zkcryptoei_generated_test.go
+++ b/vmhost/vmhooks/zkcryptoei_generated_test.go
@@ -1,0 +1,155 @@
+package vmhooks
+
+import (
+	"testing"
+
+	"github.com/consensys/gnark-crypto/ecc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestManagedVerifyGroth16_Fail_GetProofBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return(nil, assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyGroth16(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyGroth16_Fail_GetVKBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return(nil, assert.AnError)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyGroth16(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyGroth16_Fail_GetPubWitnessBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy vk"), nil)
+	managedType.On("GetBytes", int32(3)).Return(nil, assert.AnError)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyGroth16(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyGroth16_Fail_Verification(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy vk"), nil)
+	managedType.On("GetBytes", int32(3)).Return([]byte("dummy witness"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(3)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyGroth16(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyGroth16_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy vk"), nil)
+	managedType.On("GetBytes", int32(3)).Return([]byte("dummy witness"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(3)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyGroth16(int32(42), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyPlonk_Fail_GetProofBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return(nil, assert.AnError)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyPlonk(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyPlonk_Fail_GetVKBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return(nil, assert.AnError)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyPlonk(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyPlonk_Fail_GetPubWitnessBytes(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy vk"), nil)
+	managedType.On("GetBytes", int32(3)).Return(nil, assert.AnError)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(2)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyPlonk(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyPlonk_Fail_Verification(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy vk"), nil)
+	managedType.On("GetBytes", int32(3)).Return([]byte("dummy witness"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(3)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyPlonk(int32(ecc.BLS12_381), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}
+
+func TestManagedVerifyPlonk_Fail_InvalidCurve(t *testing.T) {
+	vmHooks := createHooksWithBaseSetup()
+	managedType := vmHooks.managedType
+	runtime := vmHooks.runtime
+	managedType.On("GetBytes", int32(1)).Return([]byte("dummy proof"), nil)
+	managedType.On("GetBytes", int32(2)).Return([]byte("dummy vk"), nil)
+	managedType.On("GetBytes", int32(3)).Return([]byte("dummy witness"), nil)
+	managedType.On("ConsumeGasForBytes", mock.Anything).Return(nil).Times(3)
+	runtime.On("IsUnsafeMode").Return(true)
+	runtime.On("FailExecution", mock.Anything).Return()
+
+	ret := vmHooks.hooks.ManagedVerifyPlonk(int32(42), 1, 2, 3)
+	assert.Equal(t, int32(-1), ret)
+	runtime.AssertCalled(t, "FailExecution", mock.Anything)
+}

--- a/vmhost/vmhooks/zkcryptoei_test.go
+++ b/vmhost/vmhooks/zkcryptoei_test.go
@@ -68,6 +68,7 @@ func TestManagedVerifyGroth16_Success(t *testing.T) {
 	runtime.AssertNotCalled(t, "FailExecution", mock.Anything)
 }
 
+
 func TestManagedVerifyPlonk_Success(t *testing.T) {
 	css, err := frontend.Compile(ecc.BLS12_381.ScalarField(), scs.NewBuilder, &exponentiate.Circuit{})
 	require.Nil(t, err)


### PR DESCRIPTION
This commit adds error tests for the public functions in `vmhost/vmhooks/zkcryptoei.go`.

The following functions were tested for error cases:
- `ManagedVerifyGroth16`
- `ManagedVerifyPlonk`
- `ManagedAddEC`
- `ManagedMulEC`
- `ManagedMapToCurveEC`
- `ManagedMultiExpEC`
- `ManagedPairingChecksEC`

The tests were added in new files `vmhost/vmhooks/zkcryptoei_generated_test.go` and `vmhost/vmhooks/ec_generated_test.go` to avoid OOM errors during testing.

The `ManagedVerifyZKFunctionWithHost` function was also updated to handle panics from the underlying crypto library.